### PR TITLE
Switch to non-deprecated directoryProperty() method

### DIFF
--- a/src/main/kotlin/com/mkobit/jenkins/pipelines/codegen/GenerateJavaFile.kt
+++ b/src/main/kotlin/com/mkobit/jenkins/pipelines/codegen/GenerateJavaFile.kt
@@ -43,7 +43,7 @@ open class GenerateJavaFile @Inject constructor(
    * The root directory to create the source file in.
    */
   @get:OutputDirectory
-  val srcDir: DirectoryProperty = projectLayout.directoryProperty()
+  val srcDir: DirectoryProperty = objectFactory.directoryProperty()
 
   /**
    * The destination of the Java file.


### PR DESCRIPTION
When using this plugin I was getting deprecation warnings like:

```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.5.1/userguide/command_line_interface.html#sec:command_line_warnings
```

The root cause of the warnings was:

```
The ProjectLayout.directoryProperty() method has been deprecated. This is scheduled to be removed in Gradle 6.0. Please use the ObjectFactory.directoryProperty() method instead.
```

That method is called in `GenerateJavaFile.kt`, and since that class already was injecting `ObjectFactory` I made the switch to call `objectFactory.directoryProperty()`.

Javadocs for more details on deprecation:
https://docs.gradle.org/current/javadoc/org/gradle/api/file/ProjectLayout.html#directoryProperty--

The build succeeded locally with this change when calling `./gradlew build`
