### PR TITLE
Switch to non-deprecated directoryProperty() method

### DIFF
--- a/src/main/kotlin/com/mkobit/jenkins/pipelines/JenkinsIntegrationPlugin.kt
+++ b/src/main/kotlin/com/mkobit/jenkins/pipelines/JenkinsIntegrationPlugin.kt
@@ -30,7 +30,7 @@ internal open class JenkinsIntegrationPlugin : Plugin<Project> {
         JenkinsIntegrationExtension::class.java,
         objects.property<URL>(),
         objects.property<Authentication>().apply { set(AnonymousAuthentication) },
-        layout.directoryProperty(layout.buildDirectory.dir("jenkinsIntegrationDownloads"))
+        objects.directoryProperty().apply { set(layout.buildDirectory.dir("jenkinsIntegrationDownloads")) }
       )
 
       tasks {


### PR DESCRIPTION
Following up my last PR (#91) to clean up another deprecated usage of `directoryProperty()`.

This time around the tests are not passing cleanly locally, and I'm not sure why. When I revert my changes the tests still aren't passing so I don't know if it's something with my setup or if the tests are actually currently broken on master. Hopefully the CI will shed some light on this.