### PR TITLE
chore(ci): Add GitHub Actions CI and Publish Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,149 @@
+name: Plugin CI with Gradle
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    tags:
+      - 'v?[0-9]+.[0-9]+.[0-9]+'
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE.txt'
+      - '.gitignore'
+      - 'docs/**'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE.txt'
+      - '.gitignore'
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_test_java8:
+    name: 🧪 Build & Test (Java 8, Gradle current)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: temurin
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-java8-current-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-java8-current-${{ runner.os }}-
+            gradle-java8-
+            gradle-
+
+      - name: Build & Test
+        run: ./gradlew build -P gradleTestVersions="current" --scan --stacktrace --max-workers 1
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-java8-current
+          path: build/test-results/
+
+  test_java11_current_gradle:
+    name: 🧪 Test (Java 11, Gradle current)
+    runs-on: ubuntu-latest
+    needs: build_and_test_java8
+    env:
+      LC_ALL: en_US.UTF-8
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+
+      # For Java 11 + Current Gradle
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-java11-current-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-java11-current-${{ runner.os }}-
+            gradle-java11-
+            gradle-
+
+      - name: Build & Test
+        run: ./gradlew build -P gradleTestVersions="current" --scan --stacktrace --max-workers 1
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-java11-current
+          path: build/test-results/
+
+  compatibility_matrix:
+    name: 🧪 Gradle Compatibility (Java 8, Gradle ${{ matrix.gradle }})
+    runs-on: ubuntu-latest
+    needs: build_and_test_java8
+    strategy:
+      fail-fast: false
+      matrix:
+        gradle:
+          - '5.0'
+          - '5.1.1'
+          - '5.2'
+          - '5.3.1'
+          - '5.4.1'
+          - '5.5.1'
+          - '5.6.4'
+          - '6.0.1'
+          - '6.1.1'
+          - '6.2.2'
+          - '6.3'
+          - '6.4.1'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: temurin
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-java8-v${{ matrix.gradle }}-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-java8-v${{ matrix.gradle }}-${{ runner.os }}-
+            gradle-java8-v${{ matrix.gradle }}-
+            gradle-java8-
+            gradle-
+
+      - name: Build & Test (Gradle ${{ matrix.gradle }})
+        run: ./gradlew build -P gradleTestVersions="${{ matrix.gradle }}" --stacktrace --max-workers 1
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-gradle-${{ matrix.gradle }}
+          path: build/test-results/


### PR DESCRIPTION
This PR only includes the GitHub Actions workflows without removing the existing CircleCI setup.

Also, this CI currently runs only on 'ubuntu-latest' runners.

Work towards:

- https://github.com/mkobit/jenkins-pipeline-shared-libraries-gradle-plugin/issues/110