### PR TITLE
chore: use Version Catalogs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -190,7 +190,7 @@ dependencies {
 
 tasks {
   wrapper {
-    gradleVersion = "6.8"
+    gradleVersion = "6.8.3"
   }
 
   dependencyUpdates {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bump to Gradle 7.x and use version catalogs for dependencies and plugins.