### PR TITLE
chore: remove unused kotlin-logging; regroup dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,17 @@ updates:
     cooldown:
       default-days: 14
     groups:
-      junit:
+      jetbrains:
         patterns:
-          - "org.junit.*:*"
+          - "org.jetbrains.*:*"
       kotest:
         patterns:
           - "io.kotest:*"
-      okhttp:
+      testing:
         patterns:
+          - "io.mockk:*"
           - "com.squareup.okhttp3:*"
+          - "org.junit.*:*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ dokka = "2.0.0"
 foojay = "1.0.0"
 junit-jupiter = "6.0.3"
 kotest = "6.1.11"
-kotlin-logging = "7.0.0"
 mockk = "1.13.12"
 okhttp = "4.12.0"
 openrewrite = "6.26.0"
@@ -16,7 +15,6 @@ kotest-bom = { module = "io.kotest:kotest-bom", version.ref = "kotest" }
 kotest-decoroutinator = { module = "io.kotest:kotest-extensions-decoroutinator", version.ref = "kotest" }
 kotest-engine = { module = "io.kotest:kotest-framework-engine" }
 kotest-runner = { module = "io.kotest:kotest-runner-junit5" }
-kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }


### PR DESCRIPTION
## Summary

- Removes `kotlin-logging-jvm` (`io.github.oshai:kotlin-logging-jvm`) — zero usages in source or build scripts; we use Gradle's own logger
- Adds `jetbrains` group for `org.jetbrains.*` (covers Dokka and Kotlin updates)
- Adds `testing` group combining `io.mockk`, `com.squareup.okhttp3`, and `org.junit.*` — all test-scope, arrive as one PR
- Keeps `kotest` as its own group (larger surface area, worth reviewing separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)