### PR TITLE
docs: pre-release cleanup — CI skip, RELEASING note, dependabot prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 14
+    commit-message:
+      prefix: "deps"
+      include: "scope"
     groups:
       jetbrains:
         patterns:
@@ -25,6 +28,9 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 30
+    commit-message:
+      prefix: "deps"
+      include: "scope"
     groups:
       github-actions-first-party:
         patterns:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE.txt'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE.txt'
+      - '.gitignore'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/composite-test.yml
+++ b/.github/workflows/composite-test.yml
@@ -6,7 +6,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE.txt'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE.txt'
+      - '.gitignore'
   workflow_dispatch:
     inputs:
       example-ref:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,8 +18,12 @@ Merging the release PR triggers the Release workflow, which publishes to the Gra
 |---|---|
 | `feat:` | minor |
 | `fix:`, `perf:` | patch |
-| `BREAKING CHANGE` in commit footer | major |
+| `BREAKING CHANGE` in commit footer | major (minor while pre-1.0 — see note) |
 | `deps:`, `chore:`, `ci:` | patch |
+
+> [!NOTE]
+> `release-please-config.json` sets `bump-minor-pre-major: true`, so while the released version is `0.x.y`, breaking changes bump the minor segment (e.g., `0.10.1` → `0.11.0`) rather than the major.
+> Once the project releases `1.0.0`, breaking changes bump major.
 
 ## Manual re-trigger
 


### PR DESCRIPTION
## Summary

- Adds `paths-ignore` for `*.md`, `LICENSE.txt`, and `.gitignore` to both `build.yml` and `composite-test.yml` so the functional test matrix and composite build no longer run for documentation-only changes.
- Clarifies pre-1.0 version bump behaviour in `RELEASING.md`: while the released version is `0.x.y`, `bump-minor-pre-major: true` in `release-please-config.json` causes `BREAKING CHANGE` footers to bump the minor segment, not the major.
- Adds `commit-message: prefix=deps, include=scope` to both ecosystem entries in `dependabot.yml`, so dependabot PR titles become `deps(gradle): ...` and `deps(github-actions): ...` instead of bare `Bump ...`.

## Why

Pre-release hygiene for the upcoming `0.10.1 → 0.11.0`:

- Release-prep is doc-heavy and the matrix is expensive/irrelevant for those edits.
- The current `RELEASING.md` bump table reads `BREAKING CHANGE → major`, but at `0.10.1` the next release with a breaking change lands at `0.11.0`. The note prevents surprise during the release PR.
- Dependabot PRs currently fail the `Validate PR title` check because their bare `Bump …` titles don't carry a conventional prefix. With `deps:` they pass and feed into the "Dependencies" section of the release-please changelog.

## Release pipeline safety (paths-ignore + CHANGELOG.md)

`CHANGELOG.md` is inside `**.md`, but the release pipeline still triggers correctly:

- `release-please.yml` has no `paths-ignore` — every push to main updates the release PR.
- The release PR updates `gradle.properties`, `CHANGELOG.md`, and `.release-please-manifest.json`. When it merges, the push has non-`.md` files, so `Build` runs.
- `Release` fires via `workflow_run` on Build success and gates on the `chore: release ` commit prefix.

So the only thing `**.md` actually skips is hand-curated CHANGELOG edits, README/RELEASING tweaks, etc. — none of which need the matrix.

## Test plan

- [x] CI runs against this PR (workflow YAML and `dependabot.yml` changes do not match `paths-ignore`, so `Build` and `Composite build test` still run).
- [ ] After merge, a subsequent docs-only push or PR should skip `Build` and `Composite build test` while `Validate PR title`, `Release Please`, and `Release` continue to behave normally.
- [ ] Next dependabot PR title should start with `deps(gradle):` or `deps(github-actions):` and pass `Validate PR title`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)