### PR TITLE
fix: move bootstrap-sha to parent of phoenix project merge commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
-  "bootstrap-sha": "d055cca5972590fbca2a7abcd90216f05e13b5bc",
+  "bootstrap-sha": "310cc4e8e2d879b5b41d2a02edcdf05cc0cb2484",
   "extra-files": [
     {
       "type": "generic",


### PR DESCRIPTION
## Summary

- **Root cause**: Release Please was finding 0 commits on every run. The `⚠ Could not find releases` warning in the workflow logs reveals why: there were no GitHub Releases in the repo (only git tags), so Release Please's internal releases Set was empty. When the Set is empty, the commit-fetching step returns 0 — the bootstrap-sha alone is not enough as an anchor.
- **Fix 1**: Created the [v0.10.1 GitHub Release](https://github.com/mkobit/jenkins-pipeline-shared-libraries-gradle-plugin/releases/tag/0.10.1) from the existing `0.10.1` git tag. This populates the releases Set so Release Please can fetch commits correctly.
- **Fix 2**: Moved `bootstrap-sha` from `d055cca` (the phoenix project merge commit) to `310cc4e` (its parent). The previous SHA excluded the phoenix project's own `feat:` commit, which meant only the `fix:` commit from #139 would be picked up — giving a patch bump to 0.10.2. With this change, the phoenix project's `feat: the phoenix project — ground-up revamp` is included, which triggers a minor bump to **0.11.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)