### PR TITLE
ci: split dep updates — infra prefix for GitHub Actions, hidden from changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
     cooldown:
       default-days: 30
     commit-message:
-      prefix: "deps"
+      prefix: "infra"
       include: "scope"
     groups:
       github-actions-first-party:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,9 @@ on:
       - '.gitignore'
       - 'release-please-config.json'
       - '.release-please-manifest.json'
+      - '.github/dependabot.yml'
       - '.github/workflows/release-please.yml'
+      - '.github/workflows/release.yml'
       - '.github/workflows/pr-title-check.yml'
   pull_request:
     paths-ignore:
@@ -19,7 +21,9 @@ on:
       - '.gitignore'
       - 'release-please-config.json'
       - '.release-please-manifest.json'
+      - '.github/dependabot.yml'
       - '.github/workflows/release-please.yml'
+      - '.github/workflows/release.yml'
       - '.github/workflows/pr-title-check.yml'
   workflow_dispatch:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,7 +17,7 @@
         {"type": "fix", "section": "Bug fixes"},
         {"type": "perf", "section": "Performance improvements"},
         {"type": "deps", "section": "Dependencies"},
-        {"type": "chore", "section": "Miscellaneous", "hidden": false}
+        {"type": "infra", "section": "Infrastructure", "hidden": true}
       ]
     }
   }


### PR DESCRIPTION
## Summary

- Gradle deps → `deps(gradle):` prefix → visible in changelog under **Dependencies**
- GitHub Actions pin updates → `infra(github-actions):` prefix → hidden from changelog
- Drops the visible `chore` section (internal noise for plugin consumers)

Merge after #146.