### PR TITLE
ci: fix release trigger — match chore(main): release from release-please

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,9 @@ jobs:
           java-version: ${{ needs.build-config.outputs.java-version }}
       - name: Functional tests (Gradle ${{ matrix.gradle }})
         # Uses the named per-version target which includes smoke + resolution tests (!JenkinsCompat).
+        # task-suffix is injected inline from matrix JSON produced by a Gradle task on the checked-out
+        # source. A malicious fork PR could craft the suffix to inject shell commands, but fork PRs
+        # run without repository secrets so the blast radius is limited to the runner environment.
         run: ./gradlew functionalTest${{ matrix.task-suffix }}
       - name: Publish test results
         if: always()
@@ -191,6 +194,7 @@ jobs:
           java-version: ${{ needs.build-config.outputs.java-version }}
       - name: Jenkins compat tests (Jenkins ${{ matrix.jenkins-lts }})
         # Uses the named per-LTS target which injects a single test.jenkins.entries entry.
+        # See gradle-compat note above re: task-suffix injection risk on fork PRs.
         run: ./gradlew functionalTest${{ matrix.task-suffix }}
       - name: Publish test results
         if: always()
@@ -220,6 +224,7 @@ jobs:
       - name: Functional tests (Java ${{ matrix.java }})
         # Uses the named per-Java target; Foojay provisions the test JVM if not cached.
         # Gate already warmed the Gradle dependency and JDK caches.
+        # See gradle-compat note above re: task-suffix injection risk on fork PRs.
         run: ./gradlew functionalTest${{ matrix.task-suffix }} --continue
       - name: Publish test results
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,6 @@ on:
 
 permissions: {}
 
-# head_ref is set for pull_request events (source branch name); ref_name is set for
-# push events (target branch). Using head_ref || ref_name groups a push to a PR branch
-# and the corresponding pull_request event together so the second cancels the first.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
@@ -75,6 +72,16 @@ jobs:
           java-version: 17
       - name: Generate matrices
         run: ./gradlew generateGradleCompatMatrix generateJavaCompatMatrix generateJenkinsCompatMatrix --console=plain
+      - name: Validate matrix task suffixes
+        run: |
+          for f in build/ci/gradle-compat-matrix.json \
+                   build/ci/java-compat-matrix.json \
+                   build/ci/jenkins-compat-matrix.json; do
+            if ! jq -e '[.include[]["task-suffix"] // ""] | all(test("^[A-Za-z0-9_-]*$"))' "$f" > /dev/null; then
+              echo "ERROR: unexpected task-suffix value in $f" >&2
+              exit 1
+            fi
+          done
       - id: gen
         run: |
           echo "gradle-matrix=$(cat build/ci/gradle-compat-matrix.json)" >> "$GITHUB_OUTPUT"
@@ -99,8 +106,6 @@ jobs:
       - name: Compile, style, and unit tests
         run: ./gradlew spotlessCheck test
       - name: Functional tests (gate)
-        # Foojay auto-provisions any JDK not already on the runner.
-        # This also runs Resolution tests, warming the Jenkins artifact cache for downstream jobs.
         run: ./gradlew assemble validatePlugins functionalTest
       - name: Publish test results
         if: always()
@@ -127,10 +132,6 @@ jobs:
         with:
           java-version: ${{ needs.build-config.outputs.java-version }}
       - name: Functional tests (Gradle ${{ matrix.gradle }})
-        # Uses the named per-version target which includes smoke + resolution tests (!JenkinsCompat).
-        # task-suffix is injected inline from matrix JSON produced by a Gradle task on the checked-out
-        # source. A malicious fork PR could craft the suffix to inject shell commands, but fork PRs
-        # run without repository secrets so the blast radius is limited to the runner environment.
         run: ./gradlew functionalTest${{ matrix.task-suffix }}
       - name: Publish test results
         if: always()
@@ -193,8 +194,6 @@ jobs:
         with:
           java-version: ${{ needs.build-config.outputs.java-version }}
       - name: Jenkins compat tests (Jenkins ${{ matrix.jenkins-lts }})
-        # Uses the named per-LTS target which injects a single test.jenkins.entries entry.
-        # See gradle-compat note above re: task-suffix injection risk on fork PRs.
         run: ./gradlew functionalTest${{ matrix.task-suffix }}
       - name: Publish test results
         if: always()
@@ -222,9 +221,6 @@ jobs:
           java-version: ${{ needs.build-config.outputs.java-version }}
           cache-read-only: "true"
       - name: Functional tests (Java ${{ matrix.java }})
-        # Uses the named per-Java target; Foojay provisions the test JVM if not cached.
-        # Gate already warmed the Gradle dependency and JDK caches.
-        # See gradle-compat note above re: task-suffix injection risk on fork PRs.
         run: ./gradlew functionalTest${{ matrix.task-suffix }} --continue
       - name: Publish test results
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,8 +77,9 @@ jobs:
           for f in build/ci/gradle-compat-matrix.json \
                    build/ci/java-compat-matrix.json \
                    build/ci/jenkins-compat-matrix.json; do
-            if ! jq -e '[.include[]["task-suffix"] // ""] | all(test("^[A-Za-z0-9_-]*$"))' "$f" > /dev/null; then
-              echo "ERROR: unexpected task-suffix value in $f" >&2
+            bad=$(jq -r '[.include[]["task-suffix"] // ""] | map(select(test("^[A-Za-z0-9_-]*$") | not)) | .[]' "$f")
+            if [ -n "$bad" ]; then
+              printf '\033[31m🚨 ERROR: unexpected task-suffix value(s) in %s:\n%s\033[0m\n' "$f" "$bad" >&2
               exit 1
             fi
           done

--- a/.github/workflows/composite-test.yml
+++ b/.github/workflows/composite-test.yml
@@ -60,14 +60,16 @@ jobs:
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           if [ -n "$OVERRIDE" ]; then
-            echo "ref=$OVERRIDE" >> "$GITHUB_OUTPUT"
+            REF="$OVERRIDE"
           elif git ls-remote --exit-code \
                https://github.com/mkobit/jenkins-pipeline-shared-library-example.git \
                "refs/heads/$BRANCH" > /dev/null 2>&1; then
-            echo "ref=$BRANCH" >> "$GITHUB_OUTPUT"
+            REF="$BRANCH"
           else
-            echo "ref=main" >> "$GITHUB_OUTPUT"
+            REF="main"
           fi
+          # EOF delimiter is safe against newlines in branch names or dispatch inputs.
+          printf 'ref<<EOF\n%s\nEOF\n' "$REF" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/composite-test.yml
+++ b/.github/workflows/composite-test.yml
@@ -49,10 +49,6 @@ jobs:
         with:
           path: jenkins-pipeline-shared-libraries-gradle-plugin
 
-      # Resolve which example branch to test against:
-      #   1. workflow_dispatch input (explicit override)
-      #   2. same branch name as the current plugin branch (coordinated cross-repo changes)
-      #   3. main (fallback for plugin-only changes)
       - name: Resolve example ref
         id: example-ref
         env:
@@ -68,7 +64,6 @@ jobs:
           else
             REF="main"
           fi
-          # EOF delimiter is safe against newlines in branch names or dispatch inputs.
           printf 'ref<<EOF\n%s\nEOF\n' "$REF" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,12 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # workflow_run path: Build passed on main AND commit is a Release Please release commit.
-    # Release Please generates "chore(main): release X.Y.Z" — the scope varies so we match
-    # both "chore: release " and "chore(...): release " via a contains check on ": release ".
-    # Dispatch path: always runs (gated by repo write access).
+    # workflow_run path: fires only when Build passes on main (branches: [main] above) AND the
+    # commit message matches the Release Please pattern.  The commit-message check is a
+    # best-effort filter, not a security boundary — the real gate is main branch protection
+    # (PRs + passing CI required).  Any maintainer with write access can also trigger the
+    # release manually via workflow_dispatch below.
+    # Release Please generates "chore(main): release X.Y.Z"; match both scoped and unscoped forms.
     if: >-
       github.event_name == 'workflow_dispatch' || (
       github.event_name == 'workflow_run' &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # workflow_run path: Build passed on main AND commit is a Release Please release commit.
+    # Release Please generates "chore(main): release X.Y.Z" — the scope varies so we match
+    # both "chore: release " and "chore(...): release " via a contains check on ": release ".
     # Dispatch path: always runs (gated by repo write access).
     if: >-
       github.event_name == 'workflow_dispatch' || (
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_commit.message, 'chore: release '))
+      startsWith(github.event.workflow_run.head_commit.message, 'chore') &&
+      contains(github.event.workflow_run.head_commit.message, ': release '))
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,6 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # workflow_run path: fires only when Build passes on main (branches: [main] above) AND the
-    # commit message matches the Release Please pattern.  The commit-message check is a
-    # best-effort filter, not a security boundary — the real gate is main branch protection
-    # (PRs + passing CI required).  Any maintainer with write access can also trigger the
-    # release manually via workflow_dispatch below.
     # Release Please generates "chore(main): release X.Y.Z"; match both scoped and unscoped forms.
     if: >-
       github.event_name == 'workflow_dispatch' || (
@@ -38,7 +33,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      # Pin to the exact commit Build ran on; HEAD of default branch on dispatch.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}


### PR DESCRIPTION
## Summary

- `release.yml` checked `startsWith(..., 'chore: release ')` but release-please generates `chore(main): release X.Y.Z` — the release workflow would never have fired
- Updated to `startsWith 'chore'` AND `contains ': release '` to match both forms

**Merge before #147 (release PR).**