### PR TITLE
ci: remove redundant tag and GitHub release steps from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version override — leave blank to read from build.gradle.kts'
+        description: 'Version override — leave blank to read from gradle.properties'
         required: false
         type: string
 
@@ -76,30 +76,3 @@ jobs:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         run: ./gradlew publishPlugins --no-build-cache
-
-      - name: Create and push tag
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git rev-parse "v${VERSION}" > /dev/null 2>&1; then
-            echo "Tag v${VERSION} already exists — skipping"
-          else
-            git tag -a "v${VERSION}" -m "Release ${VERSION}"
-            git push origin "v${VERSION}"
-          fi
-
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          if gh release view "v${VERSION}" > /dev/null 2>&1; then
-            echo "Release v${VERSION} already exists — skipping"
-          else
-            gh release create "v${VERSION}" \
-              --generate-notes \
-              --title "Release v${VERSION}" \
-              build/libs/*.jar
-          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["Build"]
-    types: [completed]
-    branches: [main]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       version:
@@ -23,20 +22,10 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Release Please generates "chore(main): release X.Y.Z"; match both scoped and unscoped forms.
-    if: >-
-      github.event_name == 'workflow_dispatch' || (
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_commit.message, 'chore') &&
-      contains(github.event.workflow_run.head_commit.message, ': release '))
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-          fetch-depth: 0
 
       - name: Read and validate version
         id: version


### PR DESCRIPTION
Fixes two issues with the release workflow.

**Remove redundant tag and GitHub release steps**

Release Please already creates the git tag and GitHub release when it merges the release PR. The two steps at the end of the release workflow were redundant, and the `gh release create` call used `--generate-notes` which generates notes from commit messages rather than from the CHANGELOG.

**Fix silent release failure caused by Build concurrency**

The previous trigger used `workflow_run: Build: completed` to fire the release. The Build workflow uses `cancel-in-progress: true` with a `Build-main` concurrency group — meaning any push to main while the ~45-minute Build suite was running would cancel it, and the release would silently never fire (the release job's `conclusion == 'success'` condition would fail).

Release Please pushes the `v*` tag itself when it merges the release PR, so triggering directly on the tag is both simpler and race-condition-free. The release commit only changes CHANGELOG.md and `gradle.properties`, so there is nothing to verify in a build run before publishing.

The `workflow_dispatch` escape hatch is preserved for manual recovery.