### PR TITLE
fix: use RELEASE_PAT so tag push triggers release.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         with:
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version override — leave blank to read from gradle.properties'
-        required: false
-        type: string
 
 permissions: {}
 
@@ -27,37 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Read and validate version
-        id: version
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          FILE_VERSION=$(grep '^version=' gradle.properties | cut -d= -f2)
-          if [ -n "$INPUT_VERSION" ]; then
-            if ! [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "ERROR: version must be MAJOR.MINOR.PATCH, got: $INPUT_VERSION"
-              exit 1
-            fi
-            if [ "$FILE_VERSION" != "$INPUT_VERSION" ]; then
-              echo "ERROR: gradle.properties has '$FILE_VERSION' but input is '$INPUT_VERSION'"
-              exit 1
-            fi
-            echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
-          else
-            if ! [[ "$FILE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "ERROR: version in gradle.properties must be MAJOR.MINOR.PATCH, got: $FILE_VERSION"
-              exit 1
-            fi
-            echo "version=$FILE_VERSION" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           java-version: '17'
           distribution: temurin
 
-      # Build cache disabled: prevents PR build outputs from influencing published artifacts.
-      # Distribution and dependency caches are safe (content-addressed); only task outputs are excluded.
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
 
       - name: Publish to Gradle Plugin Portal
@@ -65,3 +34,9 @@ jobs:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         run: ./gradlew publishPlugins --no-build-cache
+
+      - name: Attach artifacts to GitHub release
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.ref_name }}" build/libs/*.jar


### PR DESCRIPTION
## Summary

- `release-please.yml`: pass `RELEASE_PLEASE_TOKEN` (fine-grained token) as the action token instead of `GITHUB_TOKEN`. Tags created by a user token are user-generated events — the `push: tags:` trigger in `release.yml` fires normally. With `GITHUB_TOKEN`, it never fires (GitHub's self-trigger prevention).
- `release.yml`: remove the shell validation script and `workflow_dispatch` version input (dead code — `publishPlugins` reads the version from `gradle.properties` itself; the tag pattern in `on.push.tags` validates format). Add artifact upload step to attach `build/libs/*.jar` to the GitHub release on tag push; skipped on `workflow_dispatch` so manual recovery runs cleanly.

## Required action before merging

Add a **fine-grained token** as a repository Actions secret named `RELEASE_PLEASE_TOKEN`:

1. Go to GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
2. Generate new token with:
   - **Resource owner**: mkobit
   - **Repository access**: Only `jenkins-pipeline-shared-libraries-gradle-plugin`
   - **Permissions**: Contents (read and write), Pull requests (read and write), Issues (read and write)
   - **Expiration**: 1 year — set a calendar reminder to renew
3. Go to the repo → Settings → Secrets and variables → Actions → New repository secret
4. Name: `RELEASE_PLEASE_TOKEN`, value: the token you just created

The token is only used in `release-please.yml`. `release.yml` uses the ephemeral `GITHUB_TOKEN` for the artifact upload step.

## Recovery for 0.11.0

After this PR merges, manually trigger `workflow_dispatch` on `release.yml` from `main` to publish 0.11.0 to the Gradle Plugin Portal. The artifact upload step is skipped for `workflow_dispatch` runs — if you want to attach the JARs to the existing 0.11.0 release, run `./gradlew publishPlugins` locally then `gh release upload v0.11.0 build/libs/*.jar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)