### PR TITLE
chore: move version to gradle/version.gradle.kts for release-please compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "com.mkobit.jenkins.pipelines"
-version = version.toString().substringBefore('#').trim()
+apply(from = "gradle/version.gradle.kts")
 description = "Gradle plugins for Jenkins Pipeline shared library development and testing"
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
 }
 
 group = "com.mkobit.jenkins.pipelines"
+version = version.toString().substringBefore('#').trim()
 description = "Gradle plugins for Jenkins Pipeline shared library development and testing"
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.11.0 # x-release-please-version
+version=0.11.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,7 @@
-version=0.11.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.warning.mode=fail
-# Opt into Dokka Gradle plugin V2 (V1 removed in 2.1.0)
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/version.gradle.kts
+++ b/gradle/version.gradle.kts
@@ -1,0 +1,3 @@
+// Declared here for release-please automatic version management — see
+// https://github.com/googleapis/release-please/blob/203919b5638144b1011a308bfce8b8b5c271a7c1/docs/customizing.md?plain=1#L174
+project.version = "0.11.0" // x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
       "extra-files": [
         {
           "type": "generic",
-          "path": "gradle.properties"
+          "path": "gradle/version.gradle.kts"
         }
       ],
       "bump-minor-pre-major": true,


### PR DESCRIPTION
## Summary

release-please's generic file updater appends `# x-release-please-version` to the version line it manages. In `.properties` files, `#` is only a comment at the **start** of a line — mid-line it is a literal character. Gradle reads the full string `0.11.0 # x-release-please-version` as the project version, which the Plugin Portal rejects (`#` is not in its allowed character set).

Move the version declaration to `gradle/version.gradle.kts`, where `//` is a valid Kotlin comment and is never part of the version string:

```kotlin
project.version = "0.11.0" // x-release-please-version
```

- `gradle/version.gradle.kts` — new home for the version declaration; applied via `apply(from = "gradle/version.gradle.kts")` in `build.gradle.kts`
- `gradle.properties` — version entry removed; redundant Dokka comment removed
- `release-please-config.json` — extra-files path updated to `gradle/version.gradle.kts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)