### PR TITLE
infra: pin dependabot labels to project label set

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependency-management"
     cooldown:
       default-days: 14
     commit-message:
@@ -26,6 +28,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "infra"
     cooldown:
       default-days: 30
     commit-message:


### PR DESCRIPTION
Use `dependency-management` for Gradle updates and `infra` for GitHub Actions updates so Dependabot does not recreate the labels that were removed from the project.