### PR TITLE
infra: add infra type and remove ci from pr title check

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -30,7 +30,6 @@ jobs:
             deps
             infra
             docs
-            ci
             chore
             test
             refactor

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -28,6 +28,7 @@ jobs:
             fix
             perf
             deps
+            infra
             docs
             ci
             chore


### PR DESCRIPTION
## Summary

- Add `infra` to the allowed commit types in `pr-title-check.yml`
- Remove `ci` — workflow file changes now use `infra` instead
- Aligns the validator with the types recognized by `release-please-config.json`
- Unblocks PR #167 (`infra: pin dependabot labels to project label set`)