### PR TITLE
feat: add examples/basic-setup and examples CI

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -8,15 +8,11 @@ on:
       - 'examples/**'
       - 'src/**'
       - '.github/workflows/examples.yml'
-    paths-ignore:
-      - '**.md'
   pull_request:
     paths:
       - 'examples/**'
       - 'src/**'
       - '.github/workflows/examples.yml'
-    paths-ignore:
-      - '**.md'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,62 @@
+name: Examples
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'examples/**'
+      - 'src/**'
+      - '.github/workflows/examples.yml'
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths:
+      - 'examples/**'
+      - 'src/**'
+      - '.github/workflows/examples.yml'
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  discover:
+    name: Discover examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.list.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - id: list
+        run: |
+          matrix=$(find examples -mindepth 1 -maxdepth 1 -type d | sort | \
+                   jq -R . | jq -sc 'map({example: .}) | {include: .}')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  run:
+    name: ${{ matrix.example }}
+    needs: [discover]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: ./.github/actions/setup-env
+        with:
+          java-version: 17
+      - name: Run ${{ matrix.example }}
+        working-directory: ${{ matrix.example }}
+        run: ../../gradlew check --console=plain

--- a/examples/basic-setup/build.gradle.kts
+++ b/examples/basic-setup/build.gradle.kts
@@ -1,0 +1,20 @@
+@file:Suppress("UnstableApiUsage")
+
+import org.gradle.api.plugins.jvm.JvmTestSuite
+
+plugins {
+  id("com.mkobit.jenkins.pipelines.shared-library")
+}
+
+// All sharedLibrary defaults accepted: Jenkins 2.479.1, auto library registration, library name = "basic-setup".
+
+testing {
+  suites {
+    named<JvmTestSuite>("integrationTest") {
+      useJUnitJupiter("6.0.3")
+      dependencies {
+        runtimeOnly("org.junit.platform:junit-platform-launcher:6.0.3")
+      }
+    }
+  }
+}

--- a/examples/basic-setup/config/codenarc/codenarc.xml
+++ b/examples/basic-setup/config/codenarc/codenarc.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://codenarc.org/ruleset/1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://codenarc.org/ruleset/1.0 http://codenarc.org/ruleset-schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://codenarc.org/ruleset-schema.xsd">
+
+  <description>CodeNarc rules for the basic-setup example</description>
+
+  <ruleset-ref path="rulesets/basic.xml"/>
+  <ruleset-ref path="rulesets/braces.xml"/>
+  <ruleset-ref path="rulesets/convention.xml">
+    <!-- vars/ scripts use implicit call methods — not traditional class structure -->
+    <exclude name="MethodReturnTypeRequired"/>
+    <exclude name="VariableTypeRequired"/>
+    <exclude name="ParameterTypeRequired"/>
+    <exclude name="NoDef"/>
+    <!-- conflicts with UnnecessaryReturnKeyword from unnecessary.xml -->
+    <exclude name="ImplicitReturnStatement"/>
+    <!-- false positive: Jenkins pipeline scripts passed as string literals intentionally contain ${} expressions -->
+    <exclude name="GStringExpressionWithinString"/>
+    <!-- Jenkins shared library src classes cannot be @CompileStatic: they use CPS-transformed
+         dynamic dispatch and interact with the pipeline context via dynamic Groovy -->
+    <exclude name="CompileStatic"/>
+  </ruleset-ref>
+  <ruleset-ref path="rulesets/exceptions.xml"/>
+  <ruleset-ref path="rulesets/groovyism.xml"/>
+  <ruleset-ref path="rulesets/imports.xml"/>
+  <ruleset-ref path="rulesets/unnecessary.xml"/>
+  <ruleset-ref path="rulesets/unused.xml"/>
+
+</ruleset>

--- a/examples/basic-setup/gradle.properties
+++ b/examples/basic-setup/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.configuration-cache=true

--- a/examples/basic-setup/settings.gradle.kts
+++ b/examples/basic-setup/settings.gradle.kts
@@ -1,0 +1,32 @@
+pluginManagement {
+  includeBuild("../..")
+  repositories {
+    gradlePluginPortal()
+  }
+}
+
+plugins {
+  id("com.gradle.develocity") version "4.4.1"
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
+develocity {
+  buildScan {
+    termsOfUseUrl = "https://gradle.com/terms-of-service"
+    termsOfUseAgree = "yes"
+    publishing.onlyIf { System.getenv("DEVELOCITY_PUBLISH") == "1" }
+  }
+}
+
+dependencyResolutionManagement {
+  repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+  repositories {
+    mavenCentral()
+    maven {
+      name = "jenkins"
+      url = uri("https://repo.jenkins-ci.org/public/")
+    }
+  }
+}
+
+rootProject.name = "basic-setup"

--- a/examples/basic-setup/test/integration/java/com/example/basicsetup/SayHelloIntegrationTest.java
+++ b/examples/basic-setup/test/integration/java/com/example/basicsetup/SayHelloIntegrationTest.java
@@ -1,0 +1,20 @@
+package com.example.basicsetup;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class SayHelloIntegrationTest {
+
+  @Test
+  void sayHelloStepLogsExpectedOutput(JenkinsRule rule) throws Exception {
+    var job = rule.createProject(WorkflowJob.class, "say-hello");
+    job.setDefinition(new CpsFlowDefinition("sayHello('World')", true));
+    WorkflowRun run = rule.buildAndAssertSuccess(job);
+    rule.assertLogContains("Hello, World!", run);
+  }
+}

--- a/examples/basic-setup/vars/sayHello.groovy
+++ b/examples/basic-setup/vars/sayHello.groovy
@@ -1,0 +1,3 @@
+def call(String name) {
+  echo "Hello, ${name}!"
+}


### PR DESCRIPTION
## Summary

- Adds `examples/basic-setup/` — minimal Jenkins shared library wired against the local plugin source via `pluginManagement { includeBuild("../..") }` in its own `settings.gradle.kts`
- `vars/sayHello.groovy` step and a JUnit Jupiter integration test (`@WithJenkins`) that boots embedded Jenkins and asserts step output
- Adds `.github/workflows/examples.yml` which auto-discovers `examples/*/` directories at CI time and runs each as a parallel matrix job via `../../gradlew check`

Each example is buildable in two ways:
- From the example dir: `cd examples/basic-setup && ../../gradlew check`
- From the root composite: `./gradlew :jenkins-pipeline-shared-libraries-gradle-plugin:basic-setup:check` (parent workspace settings auto-discovers examples)

Closes #166 (first example; peer-library examples follow in separate PRs)