### PR TITLE
infra: move composite build to workflow_run, off critical path

### DIFF
--- a/.github/workflows/composite-test.yml
+++ b/.github/workflows/composite-test.yml
@@ -1,10 +1,6 @@
 name: Composite build test
 
 on:
-  workflow_run:
-    workflows: ["Build"]
-    types: [completed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       example-ref:
@@ -20,9 +16,6 @@ concurrency:
 jobs:
   build:
     name: Composite build
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/composite-test.yml
+++ b/.github/workflows/composite-test.yml
@@ -1,43 +1,28 @@
 name: Composite build test
 
 on:
-  # TODO: remove push trigger once branch protection requires PRs for all changes,
-  #       so CI only runs once per commit (via pull_request), not twice.
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE.txt'
-      - '.gitignore'
-      - 'release-please-config.json'
-      - '.release-please-manifest.json'
-      - '.github/workflows/release-please.yml'
-      - '.github/workflows/pr-title-check.yml'
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE.txt'
-      - '.gitignore'
-      - 'release-please-config.json'
-      - '.release-please-manifest.json'
-      - '.github/workflows/release-please.yml'
-      - '.github/workflows/pr-title-check.yml'
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       example-ref:
-        description: "jenkins-pipeline-shared-library-example branch/SHA to test against (default: same branch name, then main)"
+        description: "jenkins-pipeline-shared-library-example branch/SHA to test against (default: main)"
         default: ""
 
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   build:
     name: Composite build
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -53,17 +38,8 @@ jobs:
         id: example-ref
         env:
           OVERRIDE: ${{ inputs.example-ref }}
-          BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          if [ -n "$OVERRIDE" ]; then
-            REF="$OVERRIDE"
-          elif git ls-remote --exit-code \
-               https://github.com/mkobit/jenkins-pipeline-shared-library-example.git \
-               "refs/heads/$BRANCH" > /dev/null 2>&1; then
-            REF="$BRANCH"
-          else
-            REF="main"
-          fi
+          REF="${OVERRIDE:-main}"
           printf 'ref<<EOF\n%s\nEOF\n' "$REF" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
The composite build test was previously wired into both the `push` and `pull_request` triggers, making it a required check on every PR and every merge to main. This coupled the plugin's CI directly to an external repo checkout and a network probe against the example repository, adding latency and a cross-repo race condition to every run.

This PR decouples that by replacing the `push` and `pull_request` triggers with a `workflow_run` trigger that fires after the `Build` workflow completes on `main`. The composite test now runs as a follow-on, non-blocking check rather than a gating one. A `workflow_dispatch` trigger is retained so any plugin branch can be tested against any example branch on demand — you select the plugin branch in the Actions UI branch dropdown, and supply the example branch via the `example-ref` input.

The branch-matching ref resolution (which used `git ls-remote` to probe whether a same-named branch existed in the example repo) has been removed along with it — that logic only made sense in a PR context. The resolved ref is now simply the override input or `main`.

This is part of the broader work tracked in https://github.com/mkobit/jenkins-pipeline-shared-libraries-gradle-plugin/issues/166 and mirrors what was done on the example side in https://github.com/mkobit/jenkins-pipeline-shared-library-example/pull/35.
🤖 Generated with [Claude Code](https://claude.com/claude-code)