### PR TITLE
examples: add basic-vars example with JPU and integration tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "infra"
+      - "infrastructure"
     cooldown:
       default-days: 30
     commit-message:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,13 +65,14 @@ jobs:
       gradle-matrix: ${{ steps.gen.outputs.gradle-matrix }}
       java-matrix: ${{ steps.gen.outputs.java-matrix }}
       jenkins-matrix: ${{ steps.gen.outputs.jenkins-matrix }}
+      examples-matrix: ${{ steps.gen.outputs.examples-matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-env
         with:
           java-version: 17
       - name: Generate matrices
-        run: ./gradlew generateGradleCompatMatrix generateJavaCompatMatrix generateJenkinsCompatMatrix --console=plain
+        run: ./gradlew generateGradleCompatMatrix generateJavaCompatMatrix generateJenkinsCompatMatrix generateExamplesMatrix --console=plain
       - name: Validate matrix task suffixes
         run: |
           for f in build/ci/gradle-compat-matrix.json \
@@ -88,6 +89,7 @@ jobs:
           echo "gradle-matrix=$(cat build/ci/gradle-compat-matrix.json)" >> "$GITHUB_OUTPUT"
           echo "java-matrix=$(cat build/ci/java-compat-matrix.json)" >> "$GITHUB_OUTPUT"
           echo "jenkins-matrix=$(cat build/ci/jenkins-compat-matrix.json)" >> "$GITHUB_OUTPUT"
+          echo "examples-matrix=$(cat build/ci/examples-matrix.json)" >> "$GITHUB_OUTPUT"
 
   gate:
     name: Gate (Gradle ${{ needs.build-config.outputs.gradle-version }} / Java ${{ needs.build-config.outputs.java-version }})
@@ -231,9 +233,35 @@ jobs:
           check_name: 'Test results — Java ${{ matrix.java }}'
           fail_on_failure: false
 
+  examples:
+    name: Example — ${{ matrix.example }}
+    needs: [gate, matrix-gen, build-config]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix-gen.outputs.examples-matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: ./.github/actions/setup-env
+        with:
+          java-version: ${{ needs.build-config.outputs.java-version }}
+      - name: Check (${{ matrix.example }})
+        run: ./gradlew :examples:example-${{ matrix.example }} --console=plain
+      - name: Publish test results
+        if: always()
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386
+        with:
+          report_paths: 'examples/${{ matrix.example }}/build/test-results/**/*.xml'
+          check_name: 'Test results — example/${{ matrix.example }}'
+          fail_on_failure: false
+
   dependency-submission:
     name: Submit dependency graph
-    needs: [build-config, gate, gradle-compat, platform-compat, jenkins-compat, java-compat]
+    needs: [build-config, gate, gradle-compat, platform-compat, jenkins-compat, java-compat, examples]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -29,7 +29,9 @@ jobs:
             perf
             deps
             infra
+            infrastructure
             docs
+            examples
             chore
             test
             refactor

--- a/build-logic/src/main/kotlin/ci-tasks.gradle.kts
+++ b/build-logic/src/main/kotlin/ci-tasks.gradle.kts
@@ -36,6 +36,20 @@ tasks {
     outputFile = ciDir.map { it.file("jenkins-compat-matrix.json") }
   }
 
+  register<GenerateJsonMatrix>("generateExamplesMatrix") {
+    group = "CI"
+    description = "Writes the examples CI matrix JSON to <build>/ci/examples-matrix.json"
+    matrixEntries.set(
+      project
+        .file("examples")
+        .listFiles { f -> f.isDirectory }
+        ?.sortedBy { it.name }
+        ?.map { MatrixEntry(mapOf("example" to it.name)) }
+        .orEmpty(),
+    )
+    outputFile = ciDir.map { it.file("examples-matrix.json") }
+  }
+
   register<GenerateBuildConfig>("generateBuildConfig") {
     group = "CI"
     description = "Writes the wrapper Gradle version and Java toolchain spec to <build>/ci/build-config.json"

--- a/build-logic/src/main/kotlin/examples-tasks.gradle.kts
+++ b/build-logic/src/main/kotlin/examples-tasks.gradle.kts
@@ -1,0 +1,28 @@
+import org.gradle.api.plugins.JavaBasePlugin
+
+// Each example task spawns an independent Gradle process. Within that process the plugin
+// sequences test → integrationTest (mustRunAfter) and caps the integration test JVM at 2g
+// (SharedLibraryDefaults.INTEGRATION_TEST_MAX_HEAP_SIZE). The Gradle daemon for each child
+// build adds another JVM on top of that.
+//
+// With org.gradle.parallel=true in the root build, multiple example-* tasks can run
+// concurrently, stacking N×(daemon + 2g test JVM) simultaneously. This is fine for CI
+// (separate runners per matrix job) but becomes a problem if an aggregate task is ever added
+// for local use. At that point, consider a BuildService with maxParallelUsages=1 to serialize
+// example execution.
+//
+// To investigate memory across all JVMs for a single run, temporarily append "--scan" to
+// commandLine(...) below and inspect the build scan timeline.
+val gradlew = rootProject.file("gradlew")
+
+projectDir
+    .listFiles { f -> f.isDirectory && f.name != "build" }
+    ?.sortedBy { it.name }
+    ?.forEach { exampleDir ->
+        tasks.register<Exec>("example-${exampleDir.name}") {
+            group = JavaBasePlugin.VERIFICATION_GROUP
+            description = "Runs check for the ${exampleDir.name} example"
+            workingDir = exampleDir
+            commandLine(gradlew.absolutePath, "check")
+        }
+    }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,13 +155,6 @@ tasks.withType<Test>().configureEach {
   }
 }
 
-tasks.register<Exec>("example-basic-vars") {
-  group = JavaBasePlugin.VERIFICATION_GROUP
-  description = "Runs the basic-vars example build"
-  workingDir = file("examples/basic-vars")
-  commandLine(file("gradlew").absolutePath, "check")
-}
-
 // Restrict Dokka to only the hand-written src/main/kotlin sources. Without this, Dokka also
 // picks up build/generated-sources/kotlin-dsl-plugins/kotlin/SharedLibraryPlugin.kt — the
 // adapter Gradle generates for the precompiled script plugin — which has a KDoc @see reference

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,6 +155,13 @@ tasks.withType<Test>().configureEach {
   }
 }
 
+tasks.register<Exec>("example-basic-vars") {
+  group = JavaBasePlugin.VERIFICATION_GROUP
+  description = "Runs the basic-vars example build"
+  workingDir = file("examples/basic-vars")
+  commandLine(file("gradlew").absolutePath, "check")
+}
+
 // Restrict Dokka to only the hand-written src/main/kotlin sources. Without this, Dokka also
 // picks up build/generated-sources/kotlin-dsl-plugins/kotlin/SharedLibraryPlugin.kt — the
 // adapter Gradle generates for the precompiled script plugin — which has a KDoc @see reference

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,3 @@
+gradlew
+gradlew.bat
+gradle/

--- a/examples/basic-vars/build.gradle.kts
+++ b/examples/basic-vars/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("com.mkobit.jenkins.pipelines.shared-library")
+}
+
+tasks.named("codenarcMain") { enabled = false }
+tasks.named("codenarcTest") { enabled = false }
+
+testing {
+    suites {
+        named<JvmTestSuite>("test") {
+            dependencies {
+                implementation("org.codehaus.groovy:groovy:2.4.21")
+            }
+        }
+        named<JvmTestSuite>("integrationTest") {
+            useJUnit()
+        }
+    }
+}

--- a/examples/basic-vars/build.gradle.kts
+++ b/examples/basic-vars/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     id("com.mkobit.jenkins.pipelines.shared-library")
 }
 
+// TODO(#173): remove once codenarcMain is opt-in or ships a default config
+// https://github.com/mkobit/jenkins-pipeline-shared-libraries-gradle-plugin/issues/173
 tasks.named("codenarcMain") { enabled = false }
 tasks.named("codenarcTest") { enabled = false }
 
@@ -9,11 +11,12 @@ testing {
     suites {
         named<JvmTestSuite>("test") {
             dependencies {
+                // TODO(#161): remove once the plugin auto-adds groovy alongside jenkins-pipeline-unit
+                // https://github.com/mkobit/jenkins-pipeline-shared-libraries-gradle-plugin/issues/161
                 implementation("org.codehaus.groovy:groovy:2.4.21")
             }
         }
         named<JvmTestSuite>("integrationTest") {
-            useJUnit()
         }
     }
 }

--- a/examples/basic-vars/settings.gradle.kts
+++ b/examples/basic-vars/settings.gradle.kts
@@ -1,5 +1,5 @@
 pluginManagement {
-  includeBuild("../..") // use plugin from local source
+  includeBuild("../..")
   repositories {
     gradlePluginPortal()
   }

--- a/examples/basic-vars/settings.gradle.kts
+++ b/examples/basic-vars/settings.gradle.kts
@@ -1,0 +1,20 @@
+pluginManagement {
+  includeBuild("../..") // use plugin from local source
+  repositories {
+    gradlePluginPortal()
+  }
+}
+
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
+dependencyResolutionManagement {
+  repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+  repositories {
+    mavenCentral()
+    maven("https://repo.jenkins-ci.org/public/")
+  }
+}
+
+rootProject.name = "basic-vars"

--- a/examples/basic-vars/src/com/example/Greeter.groovy
+++ b/examples/basic-vars/src/com/example/Greeter.groovy
@@ -1,0 +1,9 @@
+package com.example
+
+class Greeter implements Serializable {
+    private static final long serialVersionUID = 1L
+
+    String greet(String name) {
+        "Hello, ${name}!"
+    }
+}

--- a/examples/basic-vars/test/integration/java/SayHelloStepTest.java
+++ b/examples/basic-vars/test/integration/java/SayHelloStepTest.java
@@ -1,17 +1,15 @@
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class SayHelloStepTest {
-
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+@WithJenkins
+class SayHelloStepTest {
 
     @Test
-    public void defaultGreeting() throws Exception {
+    void defaultGreeting(JenkinsRule jenkins) throws Exception {
         WorkflowJob job = jenkins.createProject(WorkflowJob.class);
         job.setDefinition(new CpsFlowDefinition("sayHello()", true));
         WorkflowRun run = jenkins.buildAndAssertSuccess(job);
@@ -19,7 +17,7 @@ public class SayHelloStepTest {
     }
 
     @Test
-    public void namedGreeting() throws Exception {
+    void namedGreeting(JenkinsRule jenkins) throws Exception {
         WorkflowJob job = jenkins.createProject(WorkflowJob.class);
         job.setDefinition(new CpsFlowDefinition("sayHello('Jenkins')", true));
         WorkflowRun run = jenkins.buildAndAssertSuccess(job);

--- a/examples/basic-vars/test/integration/java/SayHelloStepTest.java
+++ b/examples/basic-vars/test/integration/java/SayHelloStepTest.java
@@ -1,0 +1,28 @@
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class SayHelloStepTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    public void defaultGreeting() throws Exception {
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition("sayHello()", true));
+        WorkflowRun run = jenkins.buildAndAssertSuccess(job);
+        jenkins.assertLogContains("Hello, world!", run);
+    }
+
+    @Test
+    public void namedGreeting() throws Exception {
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition("sayHello('Jenkins')", true));
+        WorkflowRun run = jenkins.buildAndAssertSuccess(job);
+        jenkins.assertLogContains("Hello, Jenkins!", run);
+    }
+}

--- a/examples/basic-vars/test/unit/java/SayHelloStepTest.java
+++ b/examples/basic-vars/test/unit/java/SayHelloStepTest.java
@@ -1,0 +1,29 @@
+import com.lesfurets.jenkins.unit.BasePipelineTest;
+import groovy.lang.Script;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SayHelloStepTest extends BasePipelineTest {
+
+    @BeforeEach
+    void setup() throws Exception {
+        setScriptRoots(new String[]{"."});
+        setUp();
+    }
+
+    @Test
+    void defaultGreeting() throws Exception {
+        Script script = loadScript("vars/sayHello.groovy");
+        script.invokeMethod("call", new Object[]{});
+        assertTrue(getHelper().getCallStack().stream().anyMatch(c -> c.toString().contains("Hello, world!")));
+    }
+
+    @Test
+    void namedGreeting() throws Exception {
+        Script script = loadScript("vars/sayHello.groovy");
+        script.invokeMethod("call", new Object[]{"Jenkins"});
+        assertTrue(getHelper().getCallStack().stream().anyMatch(c -> c.toString().contains("Hello, Jenkins!")));
+    }
+}

--- a/examples/basic-vars/vars/sayHello.groovy
+++ b/examples/basic-vars/vars/sayHello.groovy
@@ -1,0 +1,6 @@
+import com.example.Greeter
+
+def call(String name = 'world') {
+    def greeter = new Greeter()
+    echo greeter.greet(name)
+}

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("examples-tasks")
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,8 +16,16 @@
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug fixes"},
         {"type": "perf", "section": "Performance improvements"},
-        {"type": "deps", "section": "Dependencies"},
-        {"type": "infra", "section": "Infrastructure", "hidden": true}
+        {"type": "deps", "section": "Dependency updates"},
+        {"type": "docs", "section": "Documentation"},
+        {"type": "examples", "section": "Documentation"},
+        {"type": "infra", "section": "Infrastructure", "hidden": true},
+        {"type": "infrastructure", "section": "Infrastructure", "hidden": true},
+        {"type": "build", "section": "Infrastructure", "hidden": true},
+        {"type": "chore", "section": "Miscellaneous", "hidden": true},
+        {"type": "test", "section": "Tests", "hidden": true},
+        {"type": "refactor", "section": "Refactoring", "hidden": true},
+        {"type": "revert", "section": "Reverts", "hidden": true}
       ]
     }
   }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,3 +27,5 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "jenkins-pipeline-shared-libraries-gradle-plugin"
+
+include("examples")


### PR DESCRIPTION
## Summary

- Introduces `examples/` directory with the first standalone example
- `basic-vars` demonstrates a `vars/` step backed by a `src/` library class, with a JPU unit test and an embedded Jenkins integration test
- `examples/.gitignore` prevents per-example wrapper jars from being committed
- `:examples` subproject registered in root settings; `examples-tasks` convention plugin auto-discovers examples and registers one `Exec` task per directory
- `generateExamplesMatrix` added to `ci-tasks` for dynamic CI matrix generation; examples run as a parallel matrix job in `build.yml`
- `release-please-config.json` expanded with full explicit changelog sections; `examples` and `infrastructure` added as valid PR title types

## Running

```
# from root
./gradlew :examples:example-basic-vars

# standalone
cd examples/basic-vars && ../../gradlew check
```

Part of #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)