### PR TITLE
docs: add kotest testing example

### DIFF
--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,40 +1,12 @@
 # Examples directory
 
-Each subdirectory is a standalone Gradle project demonstrating a usage pattern for the shared-library plugin.
+Each subdirectory is a standalone Gradle project demonstrating a plugin usage pattern.
+Run from the repo root with `./gradlew :examples:example-<name>`.
+Examples do not need their own Gradle wrapper.
 
-## Running examples
-
-From the repo root: `./gradlew :examples:example-<name>`
-
-The `:examples` project scans subdirectories and registers one `Exec` task per example.
-Each example runs in its own Gradle daemon using the **root** `gradlew` — examples do not need their own wrapper.
-
-## Creating a new example
-
-Use `basic-vars/` as the starting-point template:
-
-1. Create `examples/<name>/settings.gradle.kts` — copy from `basic-vars`, update `rootProject.name`
-2. Create `examples/<name>/build.gradle.kts` — apply `id("com.mkobit.jenkins.pipelines.shared-library")`, add any extra plugins/deps the example demonstrates
-3. Add shared library sources under `src/` and `vars/`
-4. Add tests:
-   - `test/unit/` — fast, no Jenkins runtime (Jenkins Pipeline Unit / JPU)
-   - `test/integration/` — embedded Jenkins (full harness, `@WithJenkins`, `CpsFlowDefinition`)
-
-## What the plugin auto-wires (no consumer config needed)
-
-| Area | Detail |
-|---|---|
-| `test` suite | `useJUnitJupiter()`, sources at `test/unit/{java,groovy}`, Jenkins Pipeline Unit dep |
-| `integrationTest` suite | Jenkins test harness, HPI files, WAR, `SharedLibraryAutoRegistrar`, sources at `test/integration/{java,groovy}` |
-| `groovy-all` | excluded from all compile classpaths to prevent Groovy 2.4/3.x conflicts |
-| integration task limits | `maxParallelForks = 1`, `maxHeapSize = "2g"` |
-| `check` | depends on both `test` and `integrationTest` |
+Use `basic-vars/` as the reference when adding a new example.
 
 ## Known workarounds
 
-- **CodeNarc (#173):** `codenarcMain` and `codenarcTest` are enabled by default but no config ships yet — disable them in each example until the issue is resolved:
-  ```kotlin
-  tasks.named("codenarcMain") { enabled = false }
-  tasks.named("codenarcTest") { enabled = false }
-  ```
+- **CodeNarc (#173):** disable `codenarcMain` and `codenarcTest` in each example until the issue ships a default config.
 - **Groovy on unit test classpath (#161):** add `implementation("org.codehaus.groovy:groovy:2.4.21")` to the `test` suite until the plugin auto-adds it alongside JPU.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -5,8 +5,3 @@ Run from the repo root with `./gradlew :examples:example-<name>`.
 Examples do not need their own Gradle wrapper.
 
 Use `basic-vars/` as the reference when adding a new example.
-
-## Known workarounds
-
-- **CodeNarc (#173):** disable `codenarcMain` and `codenarcTest` in each example until the issue ships a default config.
-- **Groovy on unit test classpath (#161):** add `implementation("org.codehaus.groovy:groovy:2.4.21")` to the `test` suite until the plugin auto-adds it alongside JPU.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,40 @@
+# Examples directory
+
+Each subdirectory is a standalone Gradle project demonstrating a usage pattern for the shared-library plugin.
+
+## Running examples
+
+From the repo root: `./gradlew :examples:example-<name>`
+
+The `:examples` project scans subdirectories and registers one `Exec` task per example.
+Each example runs in its own Gradle daemon using the **root** `gradlew` — examples do not need their own wrapper.
+
+## Creating a new example
+
+Use `basic-vars/` as the starting-point template:
+
+1. Create `examples/<name>/settings.gradle.kts` — copy from `basic-vars`, update `rootProject.name`
+2. Create `examples/<name>/build.gradle.kts` — apply `id("com.mkobit.jenkins.pipelines.shared-library")`, add any extra plugins/deps the example demonstrates
+3. Add shared library sources under `src/` and `vars/`
+4. Add tests:
+   - `test/unit/` — fast, no Jenkins runtime (Jenkins Pipeline Unit / JPU)
+   - `test/integration/` — embedded Jenkins (full harness, `@WithJenkins`, `CpsFlowDefinition`)
+
+## What the plugin auto-wires (no consumer config needed)
+
+| Area | Detail |
+|---|---|
+| `test` suite | `useJUnitJupiter()`, sources at `test/unit/{java,groovy}`, Jenkins Pipeline Unit dep |
+| `integrationTest` suite | Jenkins test harness, HPI files, WAR, `SharedLibraryAutoRegistrar`, sources at `test/integration/{java,groovy}` |
+| `groovy-all` | excluded from all compile classpaths to prevent Groovy 2.4/3.x conflicts |
+| integration task limits | `maxParallelForks = 1`, `maxHeapSize = "2g"` |
+| `check` | depends on both `test` and `integrationTest` |
+
+## Known workarounds
+
+- **CodeNarc (#173):** `codenarcMain` and `codenarcTest` are enabled by default but no config ships yet — disable them in each example until the issue is resolved:
+  ```kotlin
+  tasks.named("codenarcMain") { enabled = false }
+  tasks.named("codenarcTest") { enabled = false }
+  ```
+- **Groovy on unit test classpath (#161):** add `implementation("org.codehaus.groovy:groovy:2.4.21")` to the `test` suite until the plugin auto-adds it alongside JPU.

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/examples/kotest/build.gradle.kts
+++ b/examples/kotest/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    id("com.mkobit.jenkins.pipelines.shared-library")
+    kotlin("jvm") version "2.1.21"
+}
+
+// TODO(#173): remove once codenarcMain is opt-in or ships a default config
+// https://github.com/mkobit/jenkins-pipeline-shared-libraries-gradle-plugin/issues/173
+tasks.named("codenarcMain") { enabled = false }
+tasks.named("codenarcTest") { enabled = false }
+
+testing {
+    suites {
+        named<JvmTestSuite>("test") {
+            sources {
+                kotlin.setSrcDirs(listOf("test/unit/kotlin"))
+            }
+            dependencies {
+                // TODO(#161): remove once the plugin auto-adds groovy alongside jenkins-pipeline-unit
+                // https://github.com/mkobit/jenkins-pipeline-shared-libraries-gradle-plugin/issues/161
+                implementation("org.codehaus.groovy:groovy:2.4.21")
+                implementation(platform("io.kotest:kotest-bom:6.1.11"))
+                implementation("io.kotest:kotest-framework-engine")
+                implementation("io.kotest:kotest-assertions-core")
+                implementation("io.kotest:kotest-extensions-decoroutinator")
+                runtimeOnly("io.kotest:kotest-runner-junit5")
+            }
+        }
+        named<JvmTestSuite>("integrationTest") {
+            useJUnitJupiter()
+            sources {
+                kotlin.setSrcDirs(listOf("test/integration/kotlin"))
+            }
+            dependencies {
+                implementation(platform("io.kotest:kotest-bom:6.1.11"))
+                implementation("io.kotest:kotest-framework-engine")
+                implementation("io.kotest:kotest-assertions-core")
+                implementation("io.kotest:kotest-extensions-decoroutinator")
+                runtimeOnly("io.kotest:kotest-runner-junit5")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+            }
+        }
+    }
+}

--- a/examples/kotest/settings.gradle.kts
+++ b/examples/kotest/settings.gradle.kts
@@ -1,0 +1,20 @@
+pluginManagement {
+  includeBuild("../..")
+  repositories {
+    gradlePluginPortal()
+  }
+}
+
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
+dependencyResolutionManagement {
+  repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+  repositories {
+    mavenCentral()
+    maven("https://repo.jenkins-ci.org/public/")
+  }
+}
+
+rootProject.name = "kotest"

--- a/examples/kotest/src/com/example/Greeter.groovy
+++ b/examples/kotest/src/com/example/Greeter.groovy
@@ -1,0 +1,9 @@
+package com.example
+
+class Greeter implements Serializable {
+    private static final long serialVersionUID = 1L
+
+    String greet(String name) {
+        "Hello, ${name}!"
+    }
+}

--- a/examples/kotest/test/integration/kotlin/com/example/SayHelloStepTest.kt
+++ b/examples/kotest/test/integration/kotlin/com/example/SayHelloStepTest.kt
@@ -1,0 +1,23 @@
+package com.example
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import testsupport.kotest.JenkinsFunSpec
+
+class SayHelloStepTest : JenkinsFunSpec({
+    test("default greeting") {
+        jenkins { j ->
+            val job = j.createProject(WorkflowJob::class.java)
+            job.definition = CpsFlowDefinition("sayHello()", true)
+            j.assertLogContains("Hello, world!", j.buildAndAssertSuccess(job))
+        }
+    }
+
+    test("named greeting") {
+        jenkins { j ->
+            val job = j.createProject(WorkflowJob::class.java)
+            job.definition = CpsFlowDefinition("sayHello('Jenkins')", true)
+            j.assertLogContains("Hello, Jenkins!", j.buildAndAssertSuccess(job))
+        }
+    }
+})

--- a/examples/kotest/test/integration/kotlin/testsupport/kotest/JenkinsFunSpec.kt
+++ b/examples/kotest/test/integration/kotlin/testsupport/kotest/JenkinsFunSpec.kt
@@ -1,0 +1,29 @@
+package testsupport.kotest
+
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jvnet.hudson.test.JenkinsRule
+import org.jvnet.hudson.test.fixtures.JenkinsSessionFixture
+
+abstract class JenkinsFunSpec(
+    body: JenkinsFunSpec.() -> Unit,
+) : FunSpec() {
+    private val fixture = JenkinsSessionFixture()
+
+    suspend fun jenkins(block: (JenkinsRule) -> Unit) =
+        withContext(Dispatchers.IO) {
+            fixture.then(block)
+        }
+
+    init {
+        beforeTest {
+            val className = this::class.qualifiedName ?: this::class.java.name
+            fixture.setUp(className, "integration")
+        }
+        afterTest {
+            fixture.tearDown()
+        }
+        body()
+    }
+}

--- a/examples/kotest/test/integration/kotlin/testsupport/kotest/ProjectConfig.kt
+++ b/examples/kotest/test/integration/kotlin/testsupport/kotest/ProjectConfig.kt
@@ -1,0 +1,8 @@
+package testsupport.kotest
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.extensions.decoroutinator.DecoroutinatorExtension
+
+class ProjectConfig : AbstractProjectConfig() {
+    override val extensions = listOf(DecoroutinatorExtension())
+}

--- a/examples/kotest/test/unit/kotlin/com/example/SayHelloStepTest.kt
+++ b/examples/kotest/test/unit/kotlin/com/example/SayHelloStepTest.kt
@@ -1,0 +1,29 @@
+package com.example
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.inspectors.forAtLeastOne
+import io.kotest.matchers.string.shouldContain
+import org.codehaus.groovy.runtime.InvokerHelper
+
+class SayHelloStepTest : FunSpec({
+    lateinit var base: BasePipelineTest
+
+    beforeEach {
+        base =
+            object : BasePipelineTest() {}.also { t ->
+                t.setScriptRoots(".")
+                t.setUp()
+            }
+    }
+
+    test("default greeting") {
+        InvokerHelper.invokeMethod(base.loadScript("vars/sayHello.groovy"), "call", null)
+        base.helper.callStack.forAtLeastOne { it.toString() shouldContain "Hello, world!" }
+    }
+
+    test("named greeting") {
+        InvokerHelper.invokeMethod(base.loadScript("vars/sayHello.groovy"), "call", "Jenkins")
+        base.helper.callStack.forAtLeastOne { it.toString() shouldContain "Hello, Jenkins!" }
+    }
+})

--- a/examples/kotest/test/unit/kotlin/testsupport/kotest/ProjectConfig.kt
+++ b/examples/kotest/test/unit/kotlin/testsupport/kotest/ProjectConfig.kt
@@ -1,0 +1,8 @@
+package testsupport.kotest
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.extensions.decoroutinator.DecoroutinatorExtension
+
+class ProjectConfig : AbstractProjectConfig() {
+    override val extensions = listOf(DecoroutinatorExtension())
+}

--- a/examples/kotest/vars/sayHello.groovy
+++ b/examples/kotest/vars/sayHello.groovy
@@ -1,0 +1,6 @@
+import com.example.Greeter
+
+def call(String name = 'world') {
+    def greeter = new Greeter()
+    echo greeter.greet(name)
+}


### PR DESCRIPTION
Closes #177
Part of #166

Adds `examples/kotest/` — a standalone Gradle project demonstrating Kotest `FunSpec` for both unit (JPU/`BasePipelineTest`) and integration (embedded Jenkins via `JenkinsFunSpec`/`JenkinsSessionFixture`) testing of a shared library step.

Also adds `examples/AGENTS.md` and `examples/CLAUDE.md` to document the example conventions and known workarounds for future example authors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)