### PR TITLE
examples: add Jenkins Test Harness Kotest matchers to examples

### DIFF
--- a/examples/kotest/test/integration/kotlin/com/example/SayHelloStepTest.kt
+++ b/examples/kotest/test/integration/kotlin/com/example/SayHelloStepTest.kt
@@ -1,23 +1,23 @@
 package com.example
 
-import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
-import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import io.kotest.matchers.string.shouldContain
+import testsupport.jenkins.testharness.*
 import testsupport.kotest.JenkinsFunSpec
 
 class SayHelloStepTest : JenkinsFunSpec({
     test("default greeting") {
         jenkins { j ->
-            val job = j.createProject(WorkflowJob::class.java)
-            job.definition = CpsFlowDefinition("sayHello()", true)
-            j.assertLogContains("Hello, world!", j.buildAndAssertSuccess(job))
+            val job = j.createWorkflowJob(definition = "sayHello()")
+            val run = j.buildAndAssertSuccess(job)
+            run.log shouldContain "Hello, world!"
         }
     }
 
     test("named greeting") {
         jenkins { j ->
-            val job = j.createProject(WorkflowJob::class.java)
-            job.definition = CpsFlowDefinition("sayHello('Jenkins')", true)
-            j.assertLogContains("Hello, Jenkins!", j.buildAndAssertSuccess(job))
+            val job = j.createWorkflowJob(definition = "sayHello('Jenkins')")
+            val run = j.buildAndAssertSuccess(job)
+            run.log shouldContain "Hello, Jenkins!"
         }
     }
 })

--- a/examples/kotest/test/integration/kotlin/testsupport/jenkins/testharness/JenkinsRuleExtensions.kt
+++ b/examples/kotest/test/integration/kotlin/testsupport/jenkins/testharness/JenkinsRuleExtensions.kt
@@ -1,0 +1,27 @@
+package testsupport.jenkins.testharness
+
+import hudson.model.TopLevelItem
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jvnet.hudson.test.JenkinsRule
+
+/**
+ * Creates a project of the reified type [T], optionally with a [name].
+ */
+inline fun <reified T : TopLevelItem> JenkinsRule.createProject(name: String? = null): T =
+    if (name != null) {
+        createProject(T::class.java, name)
+    } else {
+        createProject(T::class.java)
+    }
+
+/**
+ * Creates a [WorkflowJob] with the given [name], optional [definition] string, and [sandbox] setting.
+ */
+fun JenkinsRule.createWorkflowJob(name: String? = null, definition: String? = null, sandbox: Boolean = true): WorkflowJob {
+    val job = createProject<WorkflowJob>(name)
+    if (definition != null) {
+        job.definition = CpsFlowDefinition(definition, sandbox)
+    }
+    return job
+}

--- a/examples/kotest/test/integration/kotlin/testsupport/jenkins/testharness/RunExtensions.kt
+++ b/examples/kotest/test/integration/kotlin/testsupport/jenkins/testharness/RunExtensions.kt
@@ -1,0 +1,13 @@
+package testsupport.jenkins.testharness
+
+import hudson.model.Run
+import org.jvnet.hudson.test.JenkinsRule
+
+/**
+ * Gets the log of a [Run] as a [String].
+ * This allows using standard Kotlin assertions (like Kotest's `shouldContain`) on the log output.
+ * Note: this is a simple fallback. If you have access to a [JenkinsRule], use `getLog(Run)`.
+ */
+val Run<*, *>.log: String
+    @Suppress("DEPRECATION") // Suppressing any potential deprecation warnings on log reading
+    get() = this.logFile.readText()


### PR DESCRIPTION
Adds Kotest helpers using extension methods for `Run` and `JenkinsRule`
to simplify Jenkins tests in the examples/kotest folder.

Fixes mkobit/jenkins-pipeline-shared-libraries-gradle-plugin#177

---
*PR created automatically by Jules for task [15427493361779195737](https://jules.google.com/task/15427493361779195737) started by @mkobit*