### PR TITLE
feat: add implicit DSL property to control @Library requirement

### DIFF
--- a/src/functionalTest/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryPluginSmokeTest.kt
+++ b/src/functionalTest/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryPluginSmokeTest.kt
@@ -257,4 +257,61 @@ class SharedLibraryPluginSmokeTest :
         }
       }
     }
+
+    describe("implicit defaults to true — integrationTest injects -Dtest.library.0.implicit=true") {
+      withData(TestedGradleVersion.filtered) { gradleVersion ->
+        withTestProject {
+          buildFile.writeText(
+            """
+            plugins {
+                id("com.mkobit.jenkins.pipelines.shared-library")
+            }
+            tasks.register("printImplicitArg") {
+                val t = tasks.integrationTest
+                doLast {
+                    val arg = t.get().jvmArgumentProviders
+                        .filterIsInstance<com.mkobit.jenkins.pipelines.LibraryImplicitArgumentProvider>()
+                        .firstOrNull()
+                        ?.asArguments()
+                        ?.firstOrNull()
+                    println("implicitArg=${'$'}arg")
+                }
+            }
+            """.trimIndent(),
+          )
+          val result = runner(gradleVersion).withArguments("printImplicitArg").build()
+          result.output shouldContain "implicitArg=-Dtest.library.0.implicit=true"
+        }
+      }
+    }
+
+    describe("implicit = false — integrationTest injects -Dtest.library.0.implicit=false") {
+      withData(TestedGradleVersion.filtered) { gradleVersion ->
+        withTestProject {
+          buildFile.writeText(
+            """
+            plugins {
+                id("com.mkobit.jenkins.pipelines.shared-library")
+            }
+            sharedLibrary {
+                implicit = false
+            }
+            tasks.register("printImplicitArg") {
+                val t = tasks.integrationTest
+                doLast {
+                    val arg = t.get().jvmArgumentProviders
+                        .filterIsInstance<com.mkobit.jenkins.pipelines.LibraryImplicitArgumentProvider>()
+                        .firstOrNull()
+                        ?.asArguments()
+                        ?.firstOrNull()
+                    println("implicitArg=${'$'}arg")
+                }
+            }
+            """.trimIndent(),
+          )
+          val result = runner(gradleVersion).withArguments("printImplicitArg").build()
+          result.output shouldContain "implicitArg=-Dtest.library.0.implicit=false"
+        }
+      }
+    }
   })

--- a/src/main/kotlin/com/mkobit/jenkins/pipelines/LibraryImplicitArgumentProvider.kt
+++ b/src/main/kotlin/com/mkobit/jenkins/pipelines/LibraryImplicitArgumentProvider.kt
@@ -1,0 +1,12 @@
+package com.mkobit.jenkins.pipelines
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.process.CommandLineArgumentProvider
+
+abstract class LibraryImplicitArgumentProvider : CommandLineArgumentProvider {
+  @get:Internal
+  abstract val implicit: Property<Boolean>
+
+  override fun asArguments() = listOf("-Dtest.library.0.implicit=${implicit.get()}")
+}

--- a/src/main/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryExtension.kt
+++ b/src/main/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryExtension.kt
@@ -114,18 +114,37 @@ abstract class SharedLibraryExtension
     abstract val autoRegisterLibrary: Property<Boolean>
 
     /**
+     * Whether the shared library is registered as implicit in embedded Jenkins.
+     * Defaults to `true` — pipeline scripts can call vars directly without a `@Library` annotation.
+     *
+     * Set to `false` to require an explicit `@Library` declaration in every pipeline:
+     * ```kotlin
+     * sharedLibrary {
+     *     libraryName = "my-pipeline-lib"
+     *     implicit = false  // pipelines must use @Library('my-pipeline-lib')
+     * }
+     * ```
+     */
+    abstract val implicit: Property<Boolean>
+
+    /**
      * Applies full Jenkins test-harness wiring to [suite] — identical to the built-in
      * `integrationTest` suite: `jenkins-test-harness`, HPI classpath, WAR path,
      * system properties, JVM opens, and `mustRunAfter("test")` ordering.
      */
     fun withJenkins(suite: JvmTestSuite) {
       jenkinsWirer.wire(suite)
-      // The library name is extension state — added here after the main wirer runs.
+      // libraryName and implicit are extension state — added here after the main wirer runs.
       suite.targets.configureEach {
         testTask.configure {
           jvmArgumentProviders.add(
             objects.newInstance<LibraryNameArgumentProvider>().apply {
               libraryName.set(this@SharedLibraryExtension.libraryName)
+            },
+          )
+          jvmArgumentProviders.add(
+            objects.newInstance<LibraryImplicitArgumentProvider>().apply {
+              implicit.set(this@SharedLibraryExtension.implicit)
             },
           )
         }

--- a/src/main/kotlin/com/mkobit/jenkins/pipelines/shared-library.gradle.kts
+++ b/src/main/kotlin/com/mkobit/jenkins/pipelines/shared-library.gradle.kts
@@ -149,6 +149,7 @@ val sharedLibrary =
       jenkins.bomVersion.convention(SharedLibraryDefaults.BOM_VERSION)
       pipelineUnitVersion.convention(SharedLibraryDefaults.PIPELINE_UNIT_VERSION)
       autoRegisterLibrary.convention(true)
+      implicit.convention(true)
       libraryName.convention(project.name)
     }
 

--- a/src/test/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryPluginTest.kt
+++ b/src/test/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryPluginTest.kt
@@ -178,6 +178,11 @@ internal class SharedLibraryPluginTest :
         ext.autoRegisterLibrary.shouldBePresent().shouldBeTrue()
       }
 
+      it("implicit defaults to true") {
+        val ext = project.extensions.getByType(SharedLibraryExtension::class.java)
+        ext.implicit.shouldBePresent().shouldBeTrue()
+      }
+
       it("libraryName defaults to project name") {
         val ext = project.extensions.getByType(SharedLibraryExtension::class.java)
         ext.libraryName shouldHaveValue project.name
@@ -190,6 +195,20 @@ internal class SharedLibraryPluginTest :
         val task = project.tasks.getByName("integrationTest") as org.gradle.api.tasks.testing.Test
         val provider = task.jvmArgumentProviders.filterIsInstance<LibraryNameArgumentProvider>().single()
         provider.libraryName shouldHaveValue ext.libraryName.shouldBePresent()
+      }
+    }
+
+    describe("implicit is reflected in test.library.0.implicit system property") {
+      it("integrationTest injects implicit=true by default") {
+        val task = project.tasks.getByName("integrationTest") as org.gradle.api.tasks.testing.Test
+        val provider = task.jvmArgumentProviders.filterIsInstance<LibraryImplicitArgumentProvider>().single()
+        provider.implicit shouldHaveValue true
+      }
+
+      it("integrationTest argument produces -Dtest.library.0.implicit=true by default") {
+        val task = project.tasks.getByName("integrationTest") as org.gradle.api.tasks.testing.Test
+        val provider = task.jvmArgumentProviders.filterIsInstance<LibraryImplicitArgumentProvider>().single()
+        provider.asArguments() shouldBe listOf("-Dtest.library.0.implicit=true")
       }
     }
 


### PR DESCRIPTION
## Summary

Adds `sharedLibrary.implicit` (`Boolean`, default `true`) so consumers can control whether the shared library is registered as implicit in embedded Jenkins. When `false`, pipeline scripts must use `@Library('name')` explicitly; when `true` (the default), vars are available without any annotation.

Implements this via a new `LibraryImplicitArgumentProvider` that injects `-Dtest.library.0.implicit=<bool>` into every Jenkins test task, wired in `withJenkins()` alongside the existing `LibraryNameArgumentProvider`. The `SharedLibraryAutoRegistrar` already read this system property (defaulting to `"true"`), so no generated-source changes were needed.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)