### PR TITLE
fix: replace @CacheableTask with @DisableCachingByDefault on ExtractJenkinsCodeNarcConfig

### DIFF
--- a/src/functionalTest/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryPluginCacheableTaskTest.kt
+++ b/src/functionalTest/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryPluginCacheableTaskTest.kt
@@ -194,27 +194,6 @@ class SharedLibraryPluginCacheableTaskTest :
           }
         }
       }
-
-      describe("is loaded FROM-CACHE when output is deleted and cache is populated") {
-        withData(TestedGradleVersion.filtered) { gradleVersion ->
-          withTestProject {
-            settingsFile.writeText(buildCacheSettings)
-            buildFile.writeText(sharedLibraryPluginBuild)
-
-            runner(gradleVersion)
-              .withArguments("extractJenkinsCodeNarcConfig", "--build-cache")
-              .build()
-              .task(":extractJenkinsCodeNarcConfig") shouldNotBeNull { outcome shouldBe TaskOutcome.SUCCESS }
-
-            dir.resolve("build/generated/codenarc/codenarc-jenkins.xml").toFile().delete()
-
-            runner(gradleVersion)
-              .withArguments("extractJenkinsCodeNarcConfig", "--build-cache")
-              .build()
-              .task(":extractJenkinsCodeNarcConfig") shouldNotBeNull { outcome shouldBe TaskOutcome.FROM_CACHE }
-          }
-        }
-      }
     }
 
     describe("extractDefaultCodeNarcConfig") {

--- a/src/main/kotlin/com/mkobit/jenkins/pipelines/ExtractJenkinsCodeNarcConfig.kt
+++ b/src/main/kotlin/com/mkobit/jenkins/pipelines/ExtractJenkinsCodeNarcConfig.kt
@@ -2,12 +2,12 @@ package com.mkobit.jenkins.pipelines
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import kotlin.io.path.outputStream
 
-@CacheableTask
+@DisableCachingByDefault(because = "Trivial classpath extraction — UP-TO-DATE checking via @OutputFile is sufficient")
 abstract class ExtractJenkinsCodeNarcConfig : DefaultTask() {
   @get:OutputFile
   abstract val outputFile: RegularFileProperty


### PR DESCRIPTION
## Summary

- `ExtractJenkinsCodeNarcConfig` had `@CacheableTask` but no tracked inputs — the cache key would be based only on task class bytecode, making caching semantically incorrect
- Replaced with `@DisableCachingByDefault` (matching the same fix already applied to `ExtractDefaultCodeNarcConfig`)
- Removed the `FROM-CACHE` functional test block for `extractJenkinsCodeNarcConfig` since the task is no longer `@CacheableTask`; the `UP-TO-DATE` block is retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)