### PR TITLE
infra(examples): add BuildService to cap concurrent example processes

### DIFF
--- a/build-logic/src/main/kotlin/examples-tasks.gradle.kts
+++ b/build-logic/src/main/kotlin/examples-tasks.gradle.kts
@@ -22,9 +22,7 @@ val gradlew = rootProject.file("gradlew")
 
 val examplesBuildService =
     gradle.sharedServices.registerIfAbsent("examples", ExamplesBuildService::class.java) {
-        maxParallelUsages.set(
-            providers.gradleProperty("examples.maxParallel").map { it.toInt() }.orElse(1)
-        )
+        maxParallelUsages = providers.gradleProperty("examples.maxParallel").map { it.toInt() }.orElse(1)
     }
 
 val exampleTasks =

--- a/build-logic/src/main/kotlin/examples-tasks.gradle.kts
+++ b/build-logic/src/main/kotlin/examples-tasks.gradle.kts
@@ -1,13 +1,14 @@
 import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
 
 // Each example task spawns an independent Gradle process. Within that process the plugin
 // sequences test → integrationTest (mustRunAfter) and caps the integration test JVM at 2g
 // (SharedLibraryDefaults.INTEGRATION_TEST_MAX_HEAP_SIZE). The Gradle daemon for each child
 // build adds another JVM on top of that.
 //
-// With org.gradle.parallel=true in the root build, multiple example-* tasks can run
-// concurrently, stacking N×(daemon + 2g test JVM) simultaneously. This is fine for CI
-// (separate runners per matrix job) but may be memory-intensive locally.
+// ExamplesBuildService caps how many example processes run at once. Default is 1 (safe on
+// any machine); override with -Pexamples.maxParallel=N for machines with more RAM.
 //
 // To investigate memory across all JVMs for a single run, temporarily append "--scan" to
 // commandLine(...) below and inspect the build scan timeline.
@@ -15,7 +16,16 @@ plugins {
     base
 }
 
+abstract class ExamplesBuildService : BuildService<BuildServiceParameters.None>
+
 val gradlew = rootProject.file("gradlew")
+
+val examplesBuildService =
+    gradle.sharedServices.registerIfAbsent("examples", ExamplesBuildService::class.java) {
+        maxParallelUsages.set(
+            providers.gradleProperty("examples.maxParallel").map { it.toInt() }.orElse(1)
+        )
+    }
 
 val exampleTasks =
     projectDir
@@ -27,6 +37,7 @@ val exampleTasks =
                 description = "Runs check for the ${exampleDir.name} example"
                 workingDir = exampleDir
                 commandLine(gradlew.absolutePath, "check")
+                usesService(examplesBuildService)
             }
         } ?: emptyList()
 


### PR DESCRIPTION
## Summary

Each `example-*` task spawns an independent Gradle process — a daemon plus a 2g integration test JVM. With `org.gradle.parallel=true`, Gradle schedules all of them concurrently, stacking N×(daemon + 2g) simultaneously. This is fine in CI where each matrix job runs in isolation, but locally it can exhaust available memory.

`ExamplesBuildService` is a sentinel `BuildService<BuildServiceParameters.None>` registered in `examples-tasks.gradle.kts`. Every example task declares `usesService`, which causes Gradle's scheduler to hold subsequent tasks until the running one finishes. The default cap is 1; machines with more RAM can pass `-Pexamples.maxParallel=N` to allow more concurrency.

This is intentionally scoped to the examples build first. Once validated, the same pattern will be applied to the plugin's own Jenkins-wired test suites to address #162.

Closes #175