### PR TITLE
chore: simplify example repository description

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Run all examples from the repo root:
 ./gradlew :examples:check
 ```
 
-See also the [example repository](https://github.com/mkobit/jenkins-pipeline-shared-library-example) for a complete project using JUnit Jupiter, Spock 2.x, and Kotest against a real Jenkins instance.
+For a complete standalone example see the [example repository](https://github.com/mkobit/jenkins-pipeline-shared-library-example).
 
 ## Running tests
 


### PR DESCRIPTION
Simplifies the description of the example repository link in the README by removing implementation-specific details.

---
*PR created automatically by Jules for task [4187794177044876868](https://jules.google.com/task/4187794177044876868) started by @mkobit*