### PR TITLE
docs: clarify autoRegisterLibrary and implicit in README and extension docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ sharedLibrary {
     pipelineUnitVersion = "1.29"                    // JenkinsPipelineUnit version (test suite)
     libraryName = "my-shared-lib"                   // Jenkins library name (default: project.name)
     autoRegisterLibrary = true                      // generate SharedLibraryAutoRegistrar (default: true)
+    implicit = true                                 // register library as implicit (default: true)
 }
 ```
 

--- a/src/main/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryExtension.kt
+++ b/src/main/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryExtension.kt
@@ -30,6 +30,8 @@ fun interface JenkinsTestSuiteWirer {
  *         bomVersion = "3463.v23b_7bb_b_b_66d5"
  *     }
  *     pipelineUnitVersion = "1.29"
+ *     autoRegisterLibrary = true
+ *     implicit = true
  *     plugins {
  *         plugin("org.jenkins-ci.plugins.workflow:workflow-multibranch")
  *     }


### PR DESCRIPTION
Adds `implicit = true` alongside `autoRegisterLibrary = true` in both the `README.md` `sharedLibrary` configuration block example and the `SharedLibraryExtension` KDoc example, to accurately and fully reflect the default configuration and properties available to the user.

---
*PR created automatically by Jules for task [1915322555273757944](https://jules.google.com/task/1915322555273757944) started by @mkobit*