### PR TITLE
chore(deps): ignore gradle-wrapper updates in examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,7 @@ updates:
       include: "scope"
     ignore:
       - dependency-name: "gradle"
+      - dependency-name: "gradle-wrapper"
     groups:
       jetbrains:
         patterns:


### PR DESCRIPTION
The example projects rely on the root project's gradle wrapper. This configures Dependabot to ignore `gradle-wrapper` updates in `/examples/*` directories so it only updates the root wrapper.

---
*PR created automatically by Jules for task [15920563880182040790](https://jules.google.com/task/15920563880182040790) started by @mkobit*