### PR TITLE
chore: resolve dokka warning for LibraryConfiguration link

### DIFF
--- a/src/main/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryExtension.kt
+++ b/src/main/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryExtension.kt
@@ -118,8 +118,7 @@ abstract class SharedLibraryExtension
       objects.property<Boolean>().convention(true)
 
     /**
-     * Controls the
-     * [implicit][org.jenkinsci.plugins.workflow.libs.LibraryConfiguration.implicit]
+     * Controls the `implicit`
      * flag on the shared library registered in the embedded Jenkins test instance.
      * When `true` (default), pipeline scripts can call vars without an explicit `@Library`
      * declaration.

--- a/src/main/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryExtension.kt
+++ b/src/main/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryExtension.kt
@@ -118,7 +118,7 @@ abstract class SharedLibraryExtension
       objects.property<Boolean>().convention(true)
 
     /**
-     * Controls the `implicit`
+     * [implicit](https://javadoc.jenkins.io/plugin/pipeline-groovy-lib/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.html#implicit)
      * flag on the shared library registered in the embedded Jenkins test instance.
      * When `true` (default), pipeline scripts can call vars without an explicit `@Library`
      * declaration.


### PR DESCRIPTION
Removed unresolvable link to `org.jenkinsci.plugins.workflow.libs.LibraryConfiguration.implicit` in `SharedLibraryExtension.kt`.

---
*PR created automatically by Jules for task [15908049133484667030](https://jules.google.com/task/15908049133484667030) started by @mkobit*