### PR TITLE
refactor: simplify TestProject builder to functional block

### DIFF
--- a/src/functionalTest/kotlin/testsupport/gradle/TestProject.kt
+++ b/src/functionalTest/kotlin/testsupport/gradle/TestProject.kt
@@ -14,30 +14,10 @@ class TestProject(
   val settingsFile: Path = dir.resolve("settings.gradle.kts")
   val buildFile: Path = dir.resolve("build.gradle.kts")
 
-  // Without an explicit -Xmx the daemon JVM uses ergonomic defaults (25% of system RAM).
-  private val gradleProperties: MutableMap<String, String> =
-    mutableMapOf("org.gradle.jvmargs" to "-Xmx512m -XX:MaxMetaspaceSize=384m")
-  private var gradlePropertiesFlushed = false
-
   fun file(path: String): Path = dir.resolve(path).also { it.parent.createDirectories() }
 
-  fun gradleProperty(
-    key: String,
-    value: String,
-  ): TestProject {
-    check(!gradlePropertiesFlushed) { "gradleProperty() called after runner() — properties already written to disk" }
-    gradleProperties[key] = value
-    return this
-  }
-
-  fun runner(gradleVersion: TestedGradleVersion): GradleRunner {
-    if (!gradlePropertiesFlushed) {
-      dir.resolve("gradle.properties").writeText(
-        gradleProperties.entries.joinToString(separator = "\n", postfix = "\n") { (k, v) -> "$k=$v" },
-      )
-      gradlePropertiesFlushed = true
-    }
-    return GradleRunner
+  fun runner(gradleVersion: TestedGradleVersion): GradleRunner =
+    GradleRunner
       .create()
       .withProjectDir(dir.toFile())
       .withGradleVersion(gradleVersion.version)
@@ -45,10 +25,19 @@ class TestProject(
       .apply {
         System.getProperty("test.gradle.user.home")?.let { withTestKitDir(Path(it).toFile()) }
       }
-  }
 }
 
 context(config: TestConfiguration)
-fun withTestProject(block: TestProject.() -> Unit) {
-  TestProject(config.tempdir("shared-library-functional-test").toPath()).block()
+fun withTestProject(
+  // Without an explicit -Xmx the daemon JVM uses ergonomic defaults (25% of system RAM).
+  gradleProperties: Map<String, String> = mapOf("org.gradle.jvmargs" to "-Xmx512m -XX:MaxMetaspaceSize=384m"),
+  block: TestProject.() -> Unit,
+) {
+  val dir = config.tempdir("shared-library-functional-test").toPath()
+  if (gradleProperties.isNotEmpty()) {
+    dir.resolve("gradle.properties").writeText(
+      gradleProperties.entries.joinToString(separator = "\n", postfix = "\n") { (k, v) -> "$k=$v" },
+    )
+  }
+  TestProject(dir).block()
 }

--- a/src/functionalTest/kotlin/testsupport/gradle/TestProject.kt
+++ b/src/functionalTest/kotlin/testsupport/gradle/TestProject.kt
@@ -6,6 +6,7 @@ import org.gradle.testkit.runner.GradleRunner
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
+import kotlin.io.path.outputStream
 import kotlin.io.path.writeText
 
 class TestProject(
@@ -35,9 +36,12 @@ fun withTestProject(
 ) {
   val dir = config.tempdir("shared-library-functional-test").toPath()
   if (gradleProperties.isNotEmpty()) {
-    dir.resolve("gradle.properties").writeText(
-      gradleProperties.entries.joinToString(separator = "\n", postfix = "\n") { (k, v) -> "$k=$v" },
-    )
+    dir.resolve("gradle.properties").outputStream().use { os ->
+      java.util
+        .Properties()
+        .apply { putAll(gradleProperties) }
+        .store(os, null)
+    }
   }
   TestProject(dir).block()
 }


### PR DESCRIPTION
This updates the `TestProject` helper so that the mutable gradle properties and builder state are removed. The API for `withTestProject` now takes the standard explicit default values. This greatly simplifies properties writing for tests by using a functional pattern rather than a delayed state-mutation map check.

---
*PR created automatically by Jules for task [9155244092934884241](https://jules.google.com/task/9155244092934884241) started by @mkobit*