### PR TITLE
chore: Use typesafe GradleProperties for test gradle.properties

### DIFF
--- a/src/functionalTest/kotlin/testsupport/gradle/TestProject.kt
+++ b/src/functionalTest/kotlin/testsupport/gradle/TestProject.kt
@@ -28,20 +28,28 @@ class TestProject(
       }
 }
 
+data class GradleProperties(
+  val jvmArgs: String? = "-Xmx512m -XX:MaxMetaspaceSize=384m",
+) {
+  fun writeTo(path: Path) {
+    val props = java.util.Properties()
+    jvmArgs?.let { props.setProperty("org.gradle.jvmargs", it) }
+
+    if (props.isNotEmpty()) {
+      path.outputStream().use { os ->
+        props.store(os, null)
+      }
+    }
+  }
+}
+
 context(config: TestConfiguration)
 fun withTestProject(
   // Without an explicit -Xmx the daemon JVM uses ergonomic defaults (25% of system RAM).
-  gradleProperties: Map<String, String> = mapOf("org.gradle.jvmargs" to "-Xmx512m -XX:MaxMetaspaceSize=384m"),
+  gradleProperties: GradleProperties = GradleProperties(),
   block: TestProject.() -> Unit,
 ) {
   val dir = config.tempdir("shared-library-functional-test").toPath()
-  if (gradleProperties.isNotEmpty()) {
-    dir.resolve("gradle.properties").outputStream().use { os ->
-      java.util
-        .Properties()
-        .apply { putAll(gradleProperties) }
-        .store(os, null)
-    }
-  }
+  gradleProperties.writeTo(dir.resolve("gradle.properties"))
   TestProject(dir).block()
 }


### PR DESCRIPTION
Refactor the way properties are written to `gradle.properties` in test configurations by replacing the use of `Map<String, String>` and `Properties.putAll` with a type-safe Kotlin data class `GradleProperties`. `putAll` is discouraged for `Properties` because it exposes `Hashtable` API allowing non-String objects. The new class correctly utilizes `setProperty()`.

---
*PR created automatically by Jules for task [735422047966012575](https://jules.google.com/task/735422047966012575) started by @mkobit*