### PR TITLE
chore: Only ignore specific markdown files in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - '**/README.md'
+      - '**/CHANGELOG.md'
+      - '**/CLAUDE.md'
       - 'LICENSE.txt'
       - '.gitignore'
       - 'release-please-config.json'
@@ -16,7 +18,9 @@ on:
       - '.github/workflows/pr-title-check.yml'
   pull_request:
     paths-ignore:
-      - '**.md'
+      - '**/README.md'
+      - '**/CHANGELOG.md'
+      - '**/CLAUDE.md'
       - 'LICENSE.txt'
       - '.gitignore'
       - 'release-please-config.json'


### PR DESCRIPTION
Replaced `**.md` ignore paths with specific files (`README.md`, `CHANGELOG.md`, `CLAUDE.md`) in `.github/workflows/build.yml` so that other markdown files are not incorrectly excluded from triggering CI builds.

---
*PR created automatically by Jules for task [10744505090458593788](https://jules.google.com/task/10744505090458593788) started by @mkobit*