### PR TITLE
deps: bump com.gradle.develocity to 4.4.2, ignore in example scopes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,7 @@ updates:
     ignore:
       - dependency-name: "gradle"
       - dependency-name: "gradle-wrapper"
+      - dependency-name: "com.gradle.develocity"
     groups:
       jetbrains:
         patterns:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.develocity") version "4.4.1"
+  id("com.gradle.develocity") version "4.4.2"
   id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 


### PR DESCRIPTION
## Summary

- Bumps `com.gradle.develocity` from 4.4.1 to 4.4.2 in root `settings.gradle.kts`.
- Adds `com.gradle.develocity` to the Dependabot ignore list for the examples block.

Develocity is declared only in the root settings.
Each example's `pluginManagement.includeBuild("../..")` caused Dependabot to open 8 duplicate PRs (one per example directory), all modifying the same root file.
Adding the ignore entry prevents recurrence.

Closes #243, #245, #246, #247, #248, #250, #251, #252.