### PR TITLE
test: assert no plugin/HPI/war configurations resolve during configuration phase

### DIFF
--- a/src/functionalTest/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryPluginResolutionTest.kt
+++ b/src/functionalTest/kotlin/com/mkobit/jenkins/pipelines/SharedLibraryPluginResolutionTest.kt
@@ -264,6 +264,62 @@ class SharedLibraryPluginResolutionTest :
       }
     }
 
+    describe("applying the plugin resolves no plugin/HPI/war configurations during configuration phase") {
+      // Resolution of jenkinsPlugin / jenkinsWar / sharedLibraryDependencies / peerLibrarySource
+      // during configuration is a footgun: it requires network, slows clean builds, and breaks
+      // the configuration-cache contract. The task body runs after configuration is fully done,
+      // so any config whose state is still UNRESOLVED was not touched by the plugin's wiring.
+      val trackedConfigurations =
+        listOf(
+          "jenkinsBom",
+          "jenkinsPlugin",
+          "jenkinsPluginHpis",
+          "jenkinsWar",
+          "sharedLibraryDependencies",
+          "sharedLibrarySourceElements",
+          "peerLibrarySource",
+          "integrationTestGroovyAllRuntime",
+          "sharedLibraryIvy",
+        )
+      withData(TestedGradleVersion.all) { gradleVersion ->
+        withTestProject {
+          settingsFile.writeText(jenkinsSettings("no-config-resolution-test"))
+          buildFile.writeText(
+            """
+            plugins {
+                id("com.mkobit.jenkins.pipelines.shared-library")
+            }
+            sharedLibrary {
+                plugins {
+                    plugin("$WORKFLOW_API")
+                }
+            }
+            tasks.register("verifyConfigurationStates") {
+                val configsByName = configurations
+                doLast {
+                    listOf(${trackedConfigurations.joinToString { "\"$it\"" }}).forEach { name ->
+                        val c = configsByName.findByName(name)
+                        println("config-state:" + name + ":" + (c?.state?.name ?: "MISSING"))
+                    }
+                }
+            }
+            """.trimIndent(),
+          )
+          val result = runner(gradleVersion).withArguments("verifyConfigurationStates").build()
+          val stateLines =
+            result.output
+              .lines()
+              .filterMatching { it.shouldStartWith("config-state:") }
+          stateLines.size shouldBe trackedConfigurations.size
+          trackedConfigurations.forEach { name ->
+            stateLines.forAtLeastOne {
+              it shouldContain "config-state:$name:UNRESOLVED"
+            }
+          }
+        }
+      }
+    }
+
     describe("BOM version constraint propagates through jenkinsPlugin") {
       withData(TestedGradleVersion.all) { gradleVersion ->
         // workflow-api is declared without a version — the BOM must supply it.


### PR DESCRIPTION
## Summary

Closes #256.

Adds a functional test that registers a `verifyConfigurationStates` task and asserts each tracked configuration is still `UNRESOLVED` when the task body runs.

Tracked configurations: `jenkinsBom`, `jenkinsPlugin`, `jenkinsPluginHpis`, `jenkinsWar`, `sharedLibraryDependencies`, `sharedLibrarySourceElements`, `peerLibrarySource`, `integrationTestGroovyAllRuntime`, `sharedLibraryIvy`.

Catches regressions where a configuration block introduces an eager `.get()` / `.resolve()` / `.files` call.

Verified the test catches regressions by temporarily adding `afterEvaluate { configurations.getByName("jenkinsWar").files }` to `shared-library.gradle.kts` — the test failed as expected.