### PR TITLE
chore: remove unused okhttp and version-catalog groovy entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,6 @@ updates:
       testing:
         patterns:
           - "io.mockk:*"
-          - "com.squareup.okhttp3:*"
           - "org.junit.*:*"
 
   - package-ecosystem: "gradle"
@@ -64,7 +63,6 @@ updates:
       testing:
         patterns:
           - "io.mockk:*"
-          - "com.squareup.okhttp3:*"
           - "org.junit.*:*"
 
   - package-ecosystem: "github-actions"

--- a/examples/version-catalog/gradle/libs.versions.toml
+++ b/examples/version-catalog/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ jenkins-bom = "5054.v620b_5d2b_d5e6"
 pipeline-unit = "1.29"
 
 [libraries]
-groovy = { module = "org.codehaus.groovy:groovy", version = "2.4.21" }
 jenkins-plugins-input = { module = "org.jenkins-ci.plugins:pipeline-input-step", version = "551.vdff487c5998c" }
 jenkins-plugins-lock = { module = "org.6wind.jenkins:lockable-resources", version = "1524.v2c727b_b_e56ef" }
 jenkins-plugins-milestone = { module = "org.jenkins-ci.plugins:pipeline-milestone-step", version = "152.v6e22b_8cfc66c" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ foojay = "1.0.0"
 junit-jupiter = "6.0.3"
 kotest = "6.1.11"
 mockk = "1.14.11"
-okhttp = "5.3.2"
 plugin-publish = "2.1.1"
 spotless = "8.6.0"
 
@@ -15,8 +14,6 @@ kotest-decoroutinator = { module = "io.kotest:kotest-extensions-decoroutinator",
 kotest-engine = { module = "io.kotest:kotest-framework-engine" }
 kotest-runner = { module = "io.kotest:kotest-runner-junit5" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }


### PR DESCRIPTION
## Summary

This change removes unused dependency declarations (`okhttp`, `okhttp-mockwebserver`, and `groovy`) from version catalogs and the `.github/dependabot.yml` configuration. These declarations were not being referenced in the source code, and their removal will prevent Dependabot from opening unnecessary pull requests for updates.

This supersedes and fixes issues addressed in #260 (bumping okhttp/mockwebserver) and #234 (bumping groovy in examples/version-catalog). After merge, both should be closed with a comment pointing here.

---
*PR created automatically by Jules for task [8281077362551456450](https://jules.google.com/task/8281077362551456450) started by @mkobit*