### PR TITLE
infra: move generateExamplesMatrix into examples convention plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           java-version: 17
       - name: Generate matrices
-        run: ./gradlew generateGradleCompatMatrix generateJavaCompatMatrix generateJenkinsCompatMatrix generateExamplesMatrix --console=plain
+        run: ./gradlew generateGradleCompatMatrix generateJavaCompatMatrix generateJenkinsCompatMatrix :examples:generateExamplesMatrix --console=plain
       - name: Validate matrix task suffixes
         run: |
           for f in build/ci/gradle-compat-matrix.json \
@@ -89,7 +89,7 @@ jobs:
           echo "gradle-matrix=$(cat build/ci/gradle-compat-matrix.json)" >> "$GITHUB_OUTPUT"
           echo "java-matrix=$(cat build/ci/java-compat-matrix.json)" >> "$GITHUB_OUTPUT"
           echo "jenkins-matrix=$(cat build/ci/jenkins-compat-matrix.json)" >> "$GITHUB_OUTPUT"
-          echo "examples-matrix=$(cat build/ci/examples-matrix.json)" >> "$GITHUB_OUTPUT"
+          echo "examples-matrix=$(cat examples/build/ci/examples-matrix.json)" >> "$GITHUB_OUTPUT"
 
   gate:
     name: Gate (Gradle ${{ needs.build-config.outputs.gradle-version }} / Java ${{ needs.build-config.outputs.java-version }})

--- a/build-logic/src/main/kotlin/ci-tasks.gradle.kts
+++ b/build-logic/src/main/kotlin/ci-tasks.gradle.kts
@@ -36,20 +36,6 @@ tasks {
     outputFile = ciDir.map { it.file("jenkins-compat-matrix.json") }
   }
 
-  register<GenerateJsonMatrix>("generateExamplesMatrix") {
-    group = "CI"
-    description = "Writes the examples CI matrix JSON to <build>/ci/examples-matrix.json"
-    matrixEntries.set(
-      project
-        .file("examples")
-        .listFiles { f -> f.isDirectory }
-        ?.sortedBy { it.name }
-        ?.map { MatrixEntry(mapOf("example" to it.name)) }
-        .orEmpty(),
-    )
-    outputFile = ciDir.map { it.file("examples-matrix.json") }
-  }
-
   register<GenerateBuildConfig>("generateBuildConfig") {
     group = "CI"
     description = "Writes the wrapper Gradle version and Java toolchain spec to <build>/ci/build-config.json"

--- a/build-logic/src/main/kotlin/examples-tasks.gradle.kts
+++ b/build-logic/src/main/kotlin/examples-tasks.gradle.kts
@@ -30,19 +30,29 @@ val examplesBuildService =
                 .orElse(1)
     }
 
-val exampleTasks =
+val exampleDirs =
     projectDir
         .listFiles { f -> f.isDirectory && f.resolve("settings.gradle.kts").exists() }
         ?.sortedBy { it.name }
-        ?.map { exampleDir ->
-            tasks.register<Exec>("example-${exampleDir.name}") {
-                group = JavaBasePlugin.VERIFICATION_GROUP
-                description = "Runs check for the ${exampleDir.name} example"
-                workingDir = exampleDir
-                commandLine(gradlew.absolutePath, "check")
-                usesService(examplesBuildService)
-            }
-        } ?: emptyList()
+        .orEmpty()
+
+val exampleTasks =
+    exampleDirs.map { exampleDir ->
+        tasks.register<Exec>("example-${exampleDir.name}") {
+            group = JavaBasePlugin.VERIFICATION_GROUP
+            description = "Runs check for the ${exampleDir.name} example"
+            workingDir = exampleDir
+            commandLine(gradlew.absolutePath, "check")
+            usesService(examplesBuildService)
+        }
+    }
+
+tasks.register<GenerateJsonMatrix>("generateExamplesMatrix") {
+    group = "CI"
+    description = "Writes the examples CI matrix JSON to <build>/ci/examples-matrix.json"
+    matrixEntries = exampleDirs.map { MatrixEntry(mapOf("example" to it.name)) }
+    outputFile = layout.buildDirectory.dir("ci").map { it.file("examples-matrix.json") }
+}
 
 tasks.check {
     dependsOn(exampleTasks)


### PR DESCRIPTION
## Summary

Closes #184.

- Moves `generateExamplesMatrix` from `build-logic/src/main/kotlin/ci-tasks.gradle.kts` into the `examples-tasks.gradle.kts` convention plugin, so the task lives next to the project that owns the `examples/` directory layout.
- Factors the example-directory scan into a single `val exampleDirs` shared by both the per-example `Exec` task registration and the matrix generator — one source of truth for "what counts as an example".
- Updates `.github/workflows/build.yml` to invoke `:examples:generateExamplesMatrix` and read the output from `examples/build/ci/examples-matrix.json`.

Drive-by: the new shared scan uses the stricter predicate (directory has a `settings.gradle.kts`), which fixes a latent bug — the old loose `f.isDirectory` filter in `ci-tasks.gradle.kts` would have included `examples/build/` as a fake example any time Gradle had populated that directory. CI never bit because the matrix step runs on a fresh checkout, but local invocations of `generateExamplesMatrix` after `:examples:check` produced a corrupted matrix.