### PR TITLE
examples: add spock example with sandbox=true pinning test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,7 @@ updates:
       - "/examples/peer-libraries-composite"
       - "/examples/version-catalog"
       - "/examples/jacoco"
+      - "/examples/spock"
     schedule:
       interval: "weekly"
     labels:

--- a/examples/spock/README.md
+++ b/examples/spock/README.md
@@ -1,0 +1,14 @@
+## Spock example
+
+Demonstrates Spock 2.x as the integration-test framework for a Jenkins shared library, exercised against a real Jenkins instance via `JenkinsRule`.
+
+### Known limitation — `sandbox=true` (issue #159)
+
+Spock 2.x brings `groovy:3.x` onto the test classpath while Jenkins still bundles `groovy-all:2.4.21` in the WAR.
+With `sandbox=true` the CPS transformer runs inside the test JVM and generates bytecode that the JVM rejects.
+With `sandbox=false` the transformer is bypassed and tests run cleanly.
+
+`SandboxLimitationPinSpec` pins the current failure mode.
+When the constraint clears upstream (Jenkins drops `groovy-all`, or a Spock variant lands with Groovy 2.x compat) the pin will start failing — that is the signal to revisit issue #159 and enable `sandbox=true` here.
+
+Use `sandbox=true` examples in the `junit-groovy`, `kotest`, and `basic` examples in the meantime; this example uses `sandbox=false` deliberately.

--- a/examples/spock/build.gradle.kts
+++ b/examples/spock/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("com.mkobit.jenkins.pipelines.shared-library")
+}
+
+testing {
+    suites {
+        named<JvmTestSuite>("integrationTest") {
+            useSpock("2.3-groovy-3.0")
+            sources {
+                groovy.setSrcDirs(listOf("test/integration/groovy"))
+            }
+            dependencies {
+                // JenkinsRule uses JUnit 4 @Rule; spock-junit4 wires that into Spock 2.x.
+                implementation("org.spockframework:spock-junit4:2.3-groovy-3.0")
+            }
+        }
+    }
+}

--- a/examples/spock/settings.gradle.kts
+++ b/examples/spock/settings.gradle.kts
@@ -1,0 +1,17 @@
+pluginManagement {
+  includeBuild("../..")
+  repositories {
+    gradlePluginPortal()
+  }
+}
+
+
+dependencyResolutionManagement {
+  repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+  repositories {
+    mavenCentral()
+    maven("https://repo.jenkins-ci.org/public/")
+  }
+}
+
+rootProject.name = "spock"

--- a/examples/spock/src/com/example/Greeter.groovy
+++ b/examples/spock/src/com/example/Greeter.groovy
@@ -1,0 +1,9 @@
+package com.example
+
+class Greeter implements Serializable {
+    private static final long serialVersionUID = 1L
+
+    String greet(String name) {
+        "Hello, ${name}!"
+    }
+}

--- a/examples/spock/test/integration/groovy/SandboxLimitationPinSpec.groovy
+++ b/examples/spock/test/integration/groovy/SandboxLimitationPinSpec.groovy
@@ -1,0 +1,38 @@
+import hudson.model.Result
+import org.junit.Rule
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jvnet.hudson.test.JenkinsRule
+import spock.lang.Specification
+
+/**
+ * Pinning test for issue #159 — Spock 2.x integration tests cannot use sandbox=true
+ * on currently supported Jenkins LTS versions.
+ *
+ * Spock 2.x brings groovy:3.x onto the test classpath; Jenkins still bundles
+ * groovy-all:2.4.21 in the WAR. With sandbox=true the CPS transformer runs inside
+ * the test JVM and generates bytecode that the JVM rejects ("Cannot reference 'toArray'
+ * before supertype constructor"). With sandbox=false the CPS transformer is bypassed
+ * and tests run cleanly (see SayHelloStepSpec).
+ *
+ * This spec pins the current failure mode. The day Jenkins drops groovy-all from the
+ * WAR — or Spock ships a groovy 2.x compatible variant — the build will start
+ * succeeding, this spec will fail, and that is the signal to revisit #159.
+ */
+class SandboxLimitationPinSpec extends Specification {
+
+    @Rule
+    JenkinsRule jenkins = new JenkinsRule()
+
+    def "sandbox=true currently fails compilation — remove this pin when it starts passing (#159)"() {
+        given:
+        def job = jenkins.createProject(WorkflowJob)
+        job.setDefinition(new CpsFlowDefinition("sayHello()", true))
+
+        when:
+        def run = jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0))
+
+        then:
+        jenkins.assertLogContains("Cannot reference 'toArray' before supertype constructor", run)
+    }
+}

--- a/examples/spock/test/integration/groovy/SayHelloStepSpec.groovy
+++ b/examples/spock/test/integration/groovy/SayHelloStepSpec.groovy
@@ -1,0 +1,35 @@
+import org.junit.Rule
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jvnet.hudson.test.JenkinsRule
+import spock.lang.Specification
+
+class SayHelloStepSpec extends Specification {
+
+    @Rule
+    JenkinsRule jenkins = new JenkinsRule()
+
+    def "default greeting runs successfully with sandbox=false"() {
+        given:
+        def job = jenkins.createProject(WorkflowJob)
+        job.setDefinition(new CpsFlowDefinition("sayHello()", false))
+
+        when:
+        def run = jenkins.buildAndAssertSuccess(job)
+
+        then:
+        jenkins.assertLogContains("Hello, world!", run)
+    }
+
+    def "named greeting runs successfully with sandbox=false"() {
+        given:
+        def job = jenkins.createProject(WorkflowJob)
+        job.setDefinition(new CpsFlowDefinition("sayHello('Jenkins')", false))
+
+        when:
+        def run = jenkins.buildAndAssertSuccess(job)
+
+        then:
+        jenkins.assertLogContains("Hello, Jenkins!", run)
+    }
+}

--- a/examples/spock/vars/sayHello.groovy
+++ b/examples/spock/vars/sayHello.groovy
@@ -1,0 +1,6 @@
+import com.example.Greeter
+
+def call(String name = 'world') {
+    def greeter = new Greeter()
+    echo greeter.greet(name)
+}


### PR DESCRIPTION
## Summary

Closes #178. Refs #159.

- Adds `examples/spock/` as a standalone example using Spock 2.x as the integration test framework for a Jenkins shared library, exercised against a real Jenkins instance via `JenkinsRule`.
- Two test methods in `SayHelloStepSpec` demonstrate the working pattern with `sandbox=false`.
- `SandboxLimitationPinSpec` pins the current `sandbox=true` failure mode for #159: it asserts the pipeline build fails with `Result.FAILURE` and the log contains the `"Cannot reference 'toArray' before supertype constructor"` compile error that the groovy 2.4 / groovy 3.x classpath conflict produces. The pin passes today; the day Jenkins drops `groovy-all` from the WAR (or Spock ships a Groovy 2.x compatible variant) the pin will start failing — that is the signal to revisit #159 and enable `sandbox=true` in this example.
- Adds `/examples/spock` to the dependabot directories list per `examples/AGENTS.md`.
- The CI examples matrix auto-discovers the new directory via the predicate from #266 (subdir with `settings.gradle.kts`).