### PR TITLE
docs: add IntelliJ import guide and examples README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ Run all examples from the repo root:
 
 For a complete standalone example see the [example repository](https://github.com/mkobit/jenkins-pipeline-shared-library-example).
 
+### IntelliJ IDEA import
+
+The main project and all examples load together in a single IntelliJ IDEA import.
+Open or import the root project directory in the IDE.
+The composite build configuration automatically registers each example as an included build.
+You can run and debug tasks (such as `:examples:example-*` or individual tests) directly from the IDE's Gradle tool window or from the code editor.
+See [examples/README.md](examples/README.md) for detailed instructions and troubleshooting notes on importing and running examples in the IDE.
+
 ## Running tests
 
 ```shell

--- a/build-logic/src/main/kotlin/ci-tasks.gradle.kts
+++ b/build-logic/src/main/kotlin/ci-tasks.gradle.kts
@@ -10,7 +10,7 @@ tasks {
   val ciDir = layout.buildDirectory.dir("ci")
 
   register<GenerateJsonMatrix>("generateGradleCompatMatrix") {
-    group = "CI"
+    group = "ci"
     description = "Writes the Gradle compat CI matrix JSON to <build>/ci/gradle-compat-matrix.json"
     matrixEntries =
       testMatrix.gradleVersions.map { version ->
@@ -20,7 +20,7 @@ tasks {
   }
 
   register<GenerateJsonMatrix>("generateJavaCompatMatrix") {
-    group = "CI"
+    group = "ci"
     description = "Writes the Java compat CI matrix JSON to <build>/ci/java-compat-matrix.json"
     matrixEntries =
       testMatrix.javaVersions.map { java ->
@@ -30,14 +30,14 @@ tasks {
   }
 
   register<GenerateJenkinsCompatMatrix>("generateJenkinsCompatMatrix") {
-    group = "CI"
+    group = "ci"
     description = "Writes the Jenkins LTS compat CI matrix JSON to <build>/ci/jenkins-compat-matrix.json"
     entries = testMatrix.jenkinsLtsEntries
     outputFile = ciDir.map { it.file("jenkins-compat-matrix.json") }
   }
 
   register<GenerateBuildConfig>("generateBuildConfig") {
-    group = "CI"
+    group = "ci"
     description = "Writes the wrapper Gradle version and Java toolchain spec to <build>/ci/build-config.json"
     gradleVersion = GradleVersion.current().version
     javaVersion = project.java.toolchain.languageVersion.map { it.asInt() }

--- a/build-logic/src/main/kotlin/examples-tasks.gradle.kts
+++ b/build-logic/src/main/kotlin/examples-tasks.gradle.kts
@@ -53,7 +53,7 @@ val exampleBuildDirs: Map<File, List<File>> =
 val exampleTasks =
     exampleDirs.map { exampleDir ->
         tasks.register<Exec>("example-${exampleDir.name}") {
-            group = "Example Verification"
+            group = "example verification"
             description = "Runs check for the ${exampleDir.name} example"
             workingDir = exampleDir
             commandLine(gradlew.absolutePath, "check")
@@ -68,7 +68,7 @@ val pruneExampleTasks =
                 listOf(dir.resolve("build"), dir.resolve(".gradle"))
             }
         tasks.register<Delete>("prune-example-${exampleDir.name}") {
-            group = "Example Maintenance"
+            group = "example maintenance"
             description =
                 "Deletes Gradle state (.gradle/, build/) for the ${exampleDir.name} example and any nested included builds"
             delete(stateDirs)
@@ -81,7 +81,7 @@ val pruneExampleTasks =
     }
 
 tasks.register("pruneAllExamples") {
-    group = "Example Maintenance"
+    group = "example maintenance"
     description = "Prunes Gradle state from every example"
     dependsOn(pruneExampleTasks)
 }

--- a/build-logic/src/main/kotlin/examples-tasks.gradle.kts
+++ b/build-logic/src/main/kotlin/examples-tasks.gradle.kts
@@ -87,7 +87,7 @@ tasks.register("pruneAllExamples") {
 }
 
 tasks.register<GenerateJsonMatrix>("generateExamplesMatrix") {
-    group = "CI"
+    group = "ci"
     description = "Writes the examples CI matrix JSON to <build>/ci/examples-matrix.json"
     matrixEntries = exampleDirs.map { MatrixEntry(mapOf("example" to it.name)) }
     outputFile = layout.buildDirectory.dir("ci").map { it.file("examples-matrix.json") }

--- a/build-logic/src/main/kotlin/examples-tasks.gradle.kts
+++ b/build-logic/src/main/kotlin/examples-tasks.gradle.kts
@@ -53,7 +53,7 @@ val exampleBuildDirs: Map<File, List<File>> =
 val exampleTasks =
     exampleDirs.map { exampleDir ->
         tasks.register<Exec>("example-${exampleDir.name}") {
-            group = JavaBasePlugin.VERIFICATION_GROUP
+            group = "Example Verification"
             description = "Runs check for the ${exampleDir.name} example"
             workingDir = exampleDir
             commandLine(gradlew.absolutePath, "check")

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,57 @@
+# Examples
+
+This directory contains standalone Gradle builds demonstrating common usage patterns of the plugin.
+
+## Running examples
+
+The repository uses a Gradle composite build configuration to include all example projects.
+You must run all Gradle tasks from the repository root using the root Gradle wrapper.
+Do not invoke Gradle from within the individual example directories (e.g., do not `cd` into an example and run gradle).
+
+### Running individual tasks
+
+You can run individual tasks of any example build using the `:<example-name>:<task-name>` syntax.
+For example, to run the `test` or `integrationTest` task for the `basic` example, run:
+
+```shell
+./gradlew :basic:test
+./gradlew :basic:integrationTest
+```
+
+### Running full checks with memory constraints
+
+The root project provides wrapper tasks in the `:examples` project named `:examples:example-<name>`.
+These tasks run the full `check` suite for an example in a separate, memory-capped process.
+For example, to run the full check for the `basic` example using this wrapper, run:
+
+```shell
+./gradlew :examples:example-basic
+```
+
+To run checks for all examples in the repository, run:
+
+```shell
+./gradlew :examples:check
+```
+
+## Importing into IntelliJ IDEA
+
+The main project and all examples load together in a single IntelliJ IDEA import.
+Open or import the root project directory `jenkins-pipeline-shared-libraries-gradle-plugin` in IntelliJ IDEA.
+The IDE automatically detects the composite build and configures all examples as included builds.
+In the IDE's Gradle tool window, each example appears as a separate Gradle project under the main build.
+You can run and debug tasks (like `check`, `test`, or `integrationTest`) directly from each example's task list in the tool window.
+You can also run or debug individual unit and integration tests directly from the code editor using the built-in test runner.
+
+## Troubleshooting
+
+### Standalone import fails
+
+The examples do not have their own Gradle wrappers or wrapper properties.
+Never open or import an example directory directly as a standalone project.
+Always open the root project instead.
+
+### Missing examples in the IDE
+
+If you add a new example directory or it does not appear in the IDE, trigger a Gradle sync.
+This runs the auto-discovery logic and imports the new example as an included build.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ This directory contains standalone Gradle builds demonstrating common usage patt
 
 The repository uses a Gradle composite build configuration to include all example projects.
 You must run all Gradle tasks from the repository root using the root Gradle wrapper.
-Do not invoke Gradle from within the individual example directories (e.g., do not `cd` into an example and run gradle).
+Do not invoke Gradle from within the individual example directories (e.g., do not `cd` into an example and run `./gradlew`).
 
 ### Running individual tasks
 
@@ -20,9 +20,9 @@ For example, to run the `test` or `integrationTest` task for the `basic` example
 
 ### Running full checks with memory constraints
 
-The root project provides wrapper tasks in the `:examples` project named `:examples:example-<name>`.
+The root project provides runner tasks in the `:examples` project named `:examples:example-<name>`.
 These tasks run the full `check` suite for an example in a separate, memory-capped process.
-For example, to run the full check for the `basic` example using this wrapper, run:
+For example, to run the full check for the `basic` example using this runner task, run:
 
 ```shell
 ./gradlew :examples:example-basic


### PR DESCRIPTION
## Summary
- Created examples/README.md with setup & import instructions
- Linked to new docs in main README.md
- Updated example task groups to lowercase