### PR TITLE
chore: configure github action to use root wrapper for examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,5 +295,4 @@ jobs:
       - uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
         with:
           build-root-directory: examples/${{ matrix.example }}
-          # The wrapper does not exist in the example directory, but in the root repository directory
-          gradle-executable: ../../gradlew
+          gradle-version: ${{ needs.build-config.outputs.gradle-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,3 +295,5 @@ jobs:
       - uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
         with:
           build-root-directory: examples/${{ matrix.example }}
+          # Examples use the root wrapper
+          gradle-executable: ../../gradlew

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,5 +295,5 @@ jobs:
       - uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
         with:
           build-root-directory: examples/${{ matrix.example }}
-          # Examples use the root wrapper
+          # The wrapper does not exist in the example directory, but in the root repository directory
           gradle-executable: ../../gradlew


### PR DESCRIPTION
## Summary

This fixes dependency graph submission failures for examples. The examples do not have their own gradle wrappers, so we need to configure the dependency submission action to use the root gradle wrapper.

---
*PR created automatically by Jules for task [691549165597731080](https://jules.google.com/task/691549165597731080) started by @mkobit*