### PR TITLE
chore: submit only root's dependency graph, drop per-example submission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,27 +282,3 @@ jobs:
           # -P project property (not an env var) since it must survive daemon reuse and
           # propagate into included builds — see the comment in settings.gradle.kts.
           additional-arguments: "-PdependencySubmission=true"
-
-  dependency-submission-examples:
-    name: Submit dependency graph — example/${{ matrix.example }}
-    needs: [build-config, matrix-gen, gate, examples]
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: write
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix-gen.outputs.examples-matrix) }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
-        with:
-          java-version: ${{ needs.build-config.outputs.java-version }}
-          distribution: temurin
-      - uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92
-        with:
-          # Root is pulled in here via this example's pluginManagement.includeBuild("../..").
-          # Same flag as the root job: stops root from including every other example back in.
-          additional-arguments: "-p examples/${{ matrix.example }} -PdependencySubmission=true"
-          gradle-version: ${{ needs.build-config.outputs.gradle-version }}


### PR DESCRIPTION
## Summary
- GitHub's Dependabot alerts aren't deduplicated across manifests. This repo's mutual `includeBuild` between root and every example (needed for examples to resolve the plugin from source) means root's own classpath gets resolved and submitted identically into all 12 manifests, inflating 51 distinct vulnerable packages into 567 open alerts.
- Confirmed via the actual plugin source (`ForceDependencyResolutionPlugin.kt`) that a genuinely unified single-manifest submission across the whole composite isn't achievable today without breaking the reverse `includeBuild` edge examples need — and there's no upstream mechanism to prune which included builds get walked (only literal self-inclusion is guarded, not two-hop mutual cycles).
- Rather than pursue that larger architectural change, this drops the per-example `dependency-submission-examples` matrix job entirely and keeps only root's manifest.

## Trade-off
Loses distinct vulnerability tracking for dependencies only examples pull in (kotest/spock/mockk, differing Jenkins plugin combos per example like `workflow-basic-steps` vs `workflow-durable-task-step`). `.github/dependabot.yml`'s version-update scanning of example directories is unaffected — that resolves dependencies independently of the submitted graph, so examples still get dependency-bump PRs, just without their own security-alert manifest.

## Test plan
- [x] Confirmed no other job/config references `dependency-submission-examples`
- [x] Confirmed branch has no protection rules requiring that check by name
- [ ] Root `Submit dependency graph` job still passes on push to main (only runs on `push`, so verify after merge)
- [ ] Open alert count drops toward the ~51-distinct-issue baseline after the next graph submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)